### PR TITLE
use memcpy instead of casted assign

### DIFF
--- a/meow_smhasher.cpp
+++ b/meow_smhasher.cpp
@@ -11,6 +11,8 @@
 
 #include "meow_hash.h"
 
+#include <string.h>
+
 //
 // NOTE(casey): 128-bit wide implementation (Meow1)
 //
@@ -19,32 +21,28 @@ void
 Meow1_32(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash1(seed, len, (void *)key);
-    *(meow_u32 *)out = (meow_u32)Result.Sub[0];
+    memcpy(out, &Result, 4);
 }
 
 void
 Meow1_64(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash1(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
+    memcpy(out, &Result, 8);
 }
 
 void
 Meow1_128(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash1(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
+    memcpy(out, &Result, 16);
 }
 
 void
 Meow1_256(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash1(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
-    ((meow_u64 *)out)[2] = Result.Sub[2];
-    ((meow_u64 *)out)[3] = Result.Sub[3];
+    memcpy(out, &Result, 32);
 }
 
 //
@@ -56,32 +54,28 @@ void
 Meow2_32(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash2(seed, len, (void *)key);
-    *(meow_u32 *)out = (meow_u32)Result.Sub[0];
+    memcpy(out, &Result, 4);
 }
 
 void
 Meow2_64(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash2(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
+    memcpy(out, &Result, 8);
 }
 
 void
 Meow2_128(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash2(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
+    memcpy(out, &Result, 16);
 }
 
 void
 Meow2_256(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash2(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
-    ((meow_u64 *)out)[2] = Result.Sub[2];
-    ((meow_u64 *)out)[3] = Result.Sub[3];
+    memcpy(out, &Result, 32);
 }
 #endif
 
@@ -94,31 +88,27 @@ void
 Meow4_32(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash4(seed, len, (void *)key);
-    *(meow_u32 *)out = (meow_u32)Result.Sub[0];
+    memcpy(out, &Result, 4);
 }
 
 void
 Meow4_64(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash4(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
+    memcpy(out, &Result, 8);
 }
 
 void
 Meow4_128(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash4(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
+    memcpy(out, &Result, 16);
 }
 
 void
 Meow4_256(const void * key, int len, meow_u32 seed, void * out)
 {
     meow_lane Result = MeowHash4(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
-    ((meow_u64 *)out)[2] = Result.Sub[2];
-    ((meow_u64 *)out)[3] = Result.Sub[3];
+    memcpy(out, &Result, 32);
 }
 #endif


### PR DESCRIPTION
This avoids any issues with strict aliasing, memcpy is the recommended way to byte-pun types instead of unions or casts.