### PR TITLE
Add hashing and predicate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,37 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{*.json,*.json.example,*.gyp,*.yml,*.yaml}]
+indent_style = space
+indent_size = 2
+
+[{*.py,*.asm}]
+indent_style = space
+
+[*.py]
+indent_size = 4
+
+[*.asm]
+indent_size = 8
+
+[*.md]
+trim_trailing_whitespace = false
+
+# Ideal settings - some plugins might support these.
+[*.js]
+quote_type = single
+
+[{*.c,*.cc,*.h,*.hh,*.cpp,*.hpp,*.m,*.mm,*.mpp,*.js,*.java,*.go,*.rs,*.php,*.ng,*.jsx,*.ts,*.d,*.cs,*.swift}]
+curly_bracket_next_line = false
+spaces_around_operators = true
+spaces_around_brackets = outside
+# close enough to 1TB
+indent_brace_style = K&R

--- a/meow_bench.cpp
+++ b/meow_bench.cpp
@@ -2,10 +2,10 @@
 
    meow_bench.cpp - basic RDTSC-based benchmark for the Meow hash
    (C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)
-   
+
    See https://mollyrocket.com/meowhash for details.
    See accompanying meow.inl for license and usage.
-   
+
    ======================================================================== */
 
 #include <intrin.h>
@@ -55,7 +55,7 @@ main(int ArgCount, char **Args)
         named_specialization Specialization = Specializations[SpecializationIndex];
         printf("    %d. %s\n", SpecializationIndex + 1, Specialization.Name);
     }
-    
+
     printf("\n");
     printf("Test results:\n");
     int Size = 32*1024;
@@ -65,7 +65,7 @@ main(int ArgCount, char **Args)
         ++Batch)
     {
         void *Buffer = _aligned_malloc(Size, 128);
-        
+
         for(int SpecializationIndex = 0;
             SpecializationIndex < (sizeof(Specializations)/sizeof(Specializations[0]));
             ++SpecializationIndex)
@@ -81,7 +81,7 @@ main(int ArgCount, char **Args)
                     meow_u64 StartClock = __rdtsc();
                     Specialization.Handler(0, Size, Buffer);
                     meow_u64 EndClock = __rdtsc();
-                    
+
                     meow_u64 Clocks = EndClock - StartClock;
                     if(BestClocks > Clocks)
                     {
@@ -103,9 +103,9 @@ main(int ArgCount, char **Args)
                 }
             }
         }
-        
+
         _aligned_free(Buffer);
-        
+
         Size *= 2;
         TestCount /= 2;
     }

--- a/meow_example.cpp
+++ b/meow_example.cpp
@@ -2,9 +2,9 @@
 
    meow_example.cpp - basic usage example of the Meow hash
    (C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)
-   
+
    See https://mollyrocket.com/meowhash for details.
-   
+
    ======================================================================== */
 
 // NOTE(casey): Meow relies on definitions for __m128/256/512, so you must
@@ -26,7 +26,7 @@ static meow_hash_implementation *MeowHash = MeowHash1;
 int MeowHashSpecializeForCPU(void)
 {
     int Result = 0;
-    
+
 #if defined(MEOW_HASH_512)
     __try
     {
@@ -53,7 +53,7 @@ int MeowHashSpecializeForCPU(void)
             Result = 128;
         }
     }
-    
+
     return(Result);
 }
 
@@ -69,11 +69,11 @@ int main(int ArgCount, char **Args)
     printf("(C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)\n");
     printf("See https://mollyrocket.com/meowhash for details.\n");
     printf("\n");
-    
+
     // NOTE(casey): Detect which MeowHash to call - do this only once, at startup.
     int BitWidth = MeowHashSpecializeForCPU();
     printf("Using %u-bit Meow implementation\n", BitWidth);
-    
+
     // NOTE(casey): Make something random to hash
     int Size = 16000;
     char *Buffer = (char *)malloc(Size);
@@ -83,15 +83,15 @@ int main(int ArgCount, char **Args)
     {
         Buffer[Index] = (char)Index;
     }
-    
+
     // NOTE(casey): Hash away!
     meow_lane Hash = MeowHash(0, Size, Buffer);
-    
+
     // NOTE(casey): Extract example smaller hash sizes you might want:
     __m128i Hash128 = Hash.L0;
     long long unsigned Hash64 = Hash.Sub[0];
     int unsigned Hash32 = Hash.Sub32[0];
-    
+
     // NOTE(casey): Print the entire 512-bit hash value using the 32-bit accessor
     // (since 64-bit printf is spec'd horribly)
     for(int Offset = 0;

--- a/meow_hash.h
+++ b/meow_hash.h
@@ -2,11 +2,11 @@
 
    Meow - A Fast Non-cryptographic Hash for Large Data Sizes
    (C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)
-   
+
    See https://mollyrocket.com/meowhash for details.
-   
+
    ========================================================================
-   
+
    zlib License
 
    (C) Copyright 2018 Molly Rocket, Inc.
@@ -28,14 +28,14 @@
    3. This notice may not be removed or altered from any source distribution.
 
    ========================================================================
-   
+
    FAQ
-   
+
    Q: What is it?
    A: Meow is a 512-bit non-cryptographic hash that operates at high speeds
       on x64 processors.  It is designed to be truncatable to 256, 128, 64,
       and 32-bit hash values and still retain good collision resistance.
-      
+
    Q: What is it GOOD for?
    A: Quickly hashing large amounts of data for comparison purposes such as
       block deduplication or file verification.  As of its publication in
@@ -46,7 +46,7 @@
       it already contains 256-wide and 512-wide hash-equivalent versions
       that can be enabled for potentially 4x faster performance on future
       VAES x64 chips when they are available.
-      
+
    Q: What is it BAD for?
    A: Anything security-related.  It is not designed for security and has
       not be analyzed for security.  It should be assumed that it offers
@@ -56,7 +56,7 @@
       block size is 256 bytes.  Generally speaking, if you're not usually
       hashing a kilobyte or more, this is probably not the hash you're
       looking for.
-      
+
    Q: Who wrote it and why?
    A: It was written by Casey Muratori (https://caseymuratori.com) for use
       in processing large-footprint assets for the game 1935
@@ -65,12 +65,12 @@
       in the pipeline, the Meow hash was designed to produce equivalent
       quality 256-bit hash values as a drop-in replacement that would take
       a fraction of the CPU time.
-      
+
    Q: Why is it called the "Meow hash"?
    A: It was created while Meow the Infinite (https://meowtheinfinite.com)
       was in development at Molly Rocket, so there were lots of Meow the
       Infinite drawings happening at that time.
-      
+
    Q: How does it work?
    A: It was designed to be the fastest possible hash that produces
       collision-free hash values in practice and passes standard hash
@@ -84,70 +84,70 @@
       front, so in the 2020 time frame when such chips start appearing,
       wider execution of Meow can be enabled without needing to change
       any persistent hash values stored in codebases, databases, etc.
-      
+
    ========================================================================
-   
+
    COMPILATION
-   
+
    To use the Meow hash, #include meow_hash.h in a single CPP file in your
    C++ project.  This will include the entire implementation.  You can
    then define your own thunk calls in that file, and define a header file
    with the API of your choice.
-   
+
    It is NOT recommended to expose the Meow hash API directly to the rest
    of your program, because it must return the hash result as a
    non-C-standard type (since the values are SSE/AVX-512/etc.), and your
    project will likely have its own types defined for these.  So at the
    very least, you will want to make a thunk call that wraps the Meow hash
    with a conversion to your preferred 128/256/512-bit type.
-   
+
    By default, only the 128-bit wide, AES-NI version of the hash will
    be compiled, because as of this publication, only the very latest
    versions of most compilers can compile VAES code.  To enable the VAES
    versions, you must use #defines:
-   
+
        #define MEOW_HASH_256 // Enables 256-wide VAES version (MeowHash2)
        #define MEOW_HASH_512 // Enables 512-wide VAES version (MeowHash4)
        #include "meow_hash.h"
-       
+
    ========================================================================
-   
+
    USAGE
-   
+
    For a complete working example, see meow_example.cpp.
-   
+
    To hash a block of data, call a MeowHash implementation:
-   
+
        #include <intrin.h>
        #include "meow_hash.h"
-       
+
        // Always available
        meow_lane MeowHash1(u64 Seed, u64 Len, void *Source);
-       
+
        // Available only if you #define MEOW_HASH_256
        meow_lane MeowHash2(u64 Seed, u64 Len, void *Source);
-       
+
        // Available only if you #define MEOW_HASH_512
        meow_lane MeowHash4(u64 Seed, u64 Len, void *Source);
-       
+
    MeowHash1 is 128-bit wide AES-NI.  MeowHash2 is 256-bit wide VAES.
    MeowHash4 is 512-bit wide VAES.  As of the initial publication of
    Meow hash, no consumer CPUs exist which support VAES, so these
    are for future use and internal x64 vendor testing.
-   
+
    Calling MeowHash* with a seed, length, and source pointer invokes the
    hash and returns a meow_lane union which contains the 512-bit result
    accessible in a number of ways (u64[8], _m128i[4], _m256i[2],
    and _m512i).  From there you can pull out what you want and discard the
    rest, as the Meow hash is designed to produce high-quality hashes
    when truncated down to anything 32 bits or greater.
-   
+
    Since no currently available CPUs can run MeowHash2 or MeowHash4,
    it is not recommended that you include them in your code, because
    they literally _cannot_ be tested.  Once CPUs are available that
    can run them, you can include them and use a probing function
    to see if they can be used at startup, as shown in meow_example.cpp.
-   
+
    ======================================================================== */
 
 #if defined(MEOW_HASH_SPECIALIZED)
@@ -161,13 +161,13 @@ MEOW_HASH_SPECIALIZED(meow_u64 Seed, meow_u64 Len, void *SourceInit)
     meow_lane IV;
     IV.Sub[0] = IV.Sub[2] = IV.Sub[4] = IV.Sub[6] = Seed;
     IV.Sub[1] = IV.Sub[3] = IV.Sub[5] = IV.Sub[7] = Seed + Len + 1;
-    
+
     // NOTE(casey): Initialize all 16 streams with the initialization vector
     meow_lane S0123 = IV;
     meow_lane S4567 = IV;
     meow_lane S89AB = IV;
     meow_lane SCDEF = IV;
-    
+
     // NOTE(casey): Handle as many full 256-byte blocks as possible
     meow_u8 *Source = (meow_u8 *)SourceInit;
     meow_u64 BlockCount = (Len >> 8);
@@ -180,7 +180,7 @@ MEOW_HASH_SPECIALIZED(meow_u64 Seed, meow_u64 Len, void *SourceInit)
         AESLoad(SCDEF, Source + 192);
         Source += (1 << 8);
     }
-    
+
     // NOTE(casey): If residual data remains, hash one final 256-byte block padded with the initialization vector
     if(Len)
     {
@@ -198,36 +198,36 @@ MEOW_HASH_SPECIALIZED(meow_u64 Seed, meow_u64 Len, void *SourceInit)
         AESMerge(S89AB, Partial[2]);
         AESMerge(SCDEF, Partial[3]);
     }
-    
+
     // NOTE(casey): Combine the 16 streams into a single hash to spread the bits out evenly
     meow_lane R0 = IV;
     AESRotate(R0, S0123);
     AESRotate(R0, S4567);
     AESRotate(R0, S89AB);
     AESRotate(R0, SCDEF);
-    
+
     AESRotate(R0, S0123);
     AESRotate(R0, S4567);
     AESRotate(R0, S89AB);
     AESRotate(R0, SCDEF);
-    
+
     AESRotate(R0, S0123);
     AESRotate(R0, S4567);
     AESRotate(R0, S89AB);
     AESRotate(R0, SCDEF);
-    
+
     AESRotate(R0, S0123);
     AESRotate(R0, S4567);
     AESRotate(R0, S89AB);
     AESRotate(R0, SCDEF);
-    
+
     // NOTE(casey): Repeat AES enough times to ensure diffusion to all bits in each 128-bit lane
     AESMerge(R0, IV);
     AESMerge(R0, IV);
     AESMerge(R0, IV);
     AESMerge(R0, IV);
     AESMerge(R0, IV);
-    
+
     return(R0);
 }
 
@@ -266,7 +266,7 @@ union meow_lane
         __m128i L2;
         __m128i L3;
     };
-    
+
     meow_u64 Sub[8];
     meow_u32 Sub32[16];
 };

--- a/meow_hash.h
+++ b/meow_hash.h
@@ -273,6 +273,42 @@ union meow_lane
 
 typedef meow_lane meow_hash_implementation(meow_u64 Seed, meow_u64 Len, void *SourceInit);
 
+namespace std {
+    template <>
+    struct hash<meow_lane>
+    {
+        std::size_t operator()(const meow_lane& k) const
+        {
+            using std::size_t;
+
+            // NOTE(qix-): branch will be optimized out at compilation time
+            switch (sizeof(std::size_t)) {
+                static_assert((sizeof(std::size_t) == 4 || sizeof(std::size_t) == 8),
+                    "size_t is something other than 32 or 64 bits - please add a hashing implementation");
+            case 4:
+                return k.Sub32[0 ] ^ k.Sub32[1 ] ^ k.Sub32[2 ] ^ k.Sub32[3 ] ^
+                       k.Sub32[4 ] ^ k.Sub32[5 ] ^ k.Sub32[6 ] ^ k.Sub32[7 ] ^
+                       k.Sub32[8 ] ^ k.Sub32[9 ] ^ k.Sub32[10] ^ k.Sub32[11] ^
+                       k.Sub32[12] ^ k.Sub32[13] ^ k.Sub32[14] ^ k.Sub32[15];
+            case 8:
+                return k.Sub[0] ^ k.Sub[1] ^ k.Sub[2] ^ k.Sub[3] ^
+                       k.Sub[4] ^ k.Sub[5] ^ k.Sub[6] ^ k.Sub[7];
+            }
+        }
+    };
+}
+
+inline bool operator ==(const meow_lane &left, const meow_lane &right) {
+    return    left.Sub[0] == right.Sub[0]
+           && left.Sub[1] == right.Sub[1]
+           && left.Sub[2] == right.Sub[2]
+           && left.Sub[3] == right.Sub[3]
+           && left.Sub[4] == right.Sub[4]
+           && left.Sub[5] == right.Sub[5]
+           && left.Sub[6] == right.Sub[6]
+           && left.Sub[7] == right.Sub[7];
+}
+
 #define MEOW_HASH_TYPES
 #endif
 

--- a/meow_smhasher.cpp
+++ b/meow_smhasher.cpp
@@ -2,9 +2,9 @@
 
    meow_smhasher.cpp - smhasher-compatible calls for the Meow hash
    (C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)
-   
+
    See https://mollyrocket.com/meowhash for license and details.
-   
+
    ======================================================================== */
 
 #include <intrin.h>


### PR DESCRIPTION
**NOTE:** based on #11. Review/merge that one first.

This adds a hashing implementation and predicate for the `meow_lane` struct. This allows `meow_lane`s to be used as a key in maps, sets, etc.