### PR TITLE
Updated Meow to v0.2/Ragdoll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Meow hash
 This is the official x64 implementation of the Meow hash, an extremely fast non-cryptographic hash.  See https://mollyrocket.com/meowhash for usage, implementation, and license details.
 
-This version is v0.1 and is EXPERIMENTAL.  It is only designed for testing and comment right now.  Updates will be coming which finalize the hash function, but for right now it is still considered in flux.  Linux/Mac buildable versions will also be forthcoming.
+This version is v0.2 and is EXPERIMENTAL.  It is only designed for testing and comment right now.  Updates will be coming which finalize the hash function, but for right now it is still considered in flux.  Linux/Mac buildable versions will also be forthcoming.

--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,8 @@
 @echo off
-cl /Oi /O2 /Zi meow_example.cpp
+mkdir build
+pushd build
+cl %* -I../ /FC /Oi /O2 /Zi /arch:AVX ..\meow_example.cpp
+cl %* -I../ /EHsc /FC /Oi /O2 /Zi /arch:AVX ..\utils\meow_test.cpp
+cl %* -I../ /FC /Oi /O2 /Zi /arch:AVX ..\utils\meow_search.cpp
+cl %* -I../ /FC /Oi /O2 /Zi /arch:AVX ..\utils\meow_bench.cpp
+popd

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+mkdir -p build
+clang $* -I./ meow_example.cpp -O3 -mavx -maes -obuild/meow_example -lstdc++
+clang $* -I./ utils/meow_test.cpp -O3 -mavx -maes -obuild/meow_test -lstdc++
+clang $* -I./ utils/meow_search.cpp -O3 -mavx -maes -obuild/meow_search -lstdc++
+clang $* -I./ utils/meow_bench.cpp -O3 -mavx -maes -obuild/meow_bench -lstdc++

--- a/meow_example.cpp
+++ b/meow_example.cpp
@@ -7,18 +7,46 @@
    
    ======================================================================== */
 
+#include <stdio.h>
+#include <memory.h>
+
+#if _MSC_VER
+// NOTE(casey): Sadly, Visual Studio STILL doesn't seem to support standard
+// C, so you have to use their weird aligned malloc.
+#define aligned_alloc(a,b) _aligned_malloc(b,a)
+#define free _aligned_free
+#endif
+
+//
+// NOTE(casey): entire_file / ReadEntireFile / FreeEntireFile are simple helpers
+// for loading a file into memory.  They are defined at the end of this file.
+//
+struct entire_file
+{
+    size_t Size;
+    void *Contents;
+};
+static entire_file ReadEntireFile(char *Filename);
+static void FreeEntireFile(entire_file *File);
+
+//
+// NOTE(casey): Step 1 - include your intrinsics header, the include meow_hash.h
+//
+
 // NOTE(casey): Meow relies on definitions for __m128/256/512, so you must
 // have those defined either in your own include files or via a standard .h:
+#if _MSC_VER
 #include <intrin.h>
-
-// NOTE(casey): We ask for all three versions here - if you only want the
-// 128-bit version, you can omit the two #define's.
-#define MEOW_HASH_256
-#define MEOW_HASH_512
+#else
+#include <x86intrin.h>
+#endif
 #include "meow_hash.h"
 
 //
-// NOTE(casey): Instruction-set testing
+// NOTE(casey): Step 2 (optional) - for future-proofing, detect which Meow hash the CPU can run
+//
+// This is COMPLETELY OPTIONAL - you can instead just always call MeowHash1 to use
+// the 128-bit-wide version exclusively.
 //
 
 static meow_hash_implementation *MeowHash = MeowHash1;
@@ -27,26 +55,26 @@ int MeowHashSpecializeForCPU(void)
 {
     int Result = 0;
     
-#if defined(MEOW_HASH_512)
-    __try
+#if MEOW_HASH_AVX512
+    try
     {
         char Garbage[64];
         MeowHash4(0, sizeof(Garbage), Garbage);
         MeowHash = MeowHash4;
         Result = 512;
     }
-    __except(1)
+    catch(...)
 #endif
     {
-#if defined(MEOW_HASH_256)
-        __try
+#if MEOW_HASH_AVX512
+        try
         {
             char Garbage[64];
             MeowHash2(0, sizeof(Garbage), Garbage);
             MeowHash = MeowHash2;
             Result = 256;
         }
-        __except(1)
+        catch(...)
 #endif
         {
             MeowHash = MeowHash1;
@@ -58,14 +86,131 @@ int MeowHashSpecializeForCPU(void)
 }
 
 //
-// NOTE(casey): Usage
+// NOTE(casey): Step 3 - use the Meow hash in a variety of ways!
+//
+// Example functions below:
+//   PrintHash - how to print a Meow hash to stdout, from highest-order 32-bits to lowest
+//   HashTestBuffer - how to have Meow hash a buffer of data
+//   HashOneFile - have Meow hash the contents of a file
+//   CompareTwoFiles - have Meow hash the contents of two files, and check for equivalence
+
+static void
+PrintHash(meow_hash Hash)
+{
+    printf("    %08X-%08X-%08X-%08X\n",
+           Hash.u32[ 3],
+           Hash.u32[ 2],
+           Hash.u32[ 1],
+           Hash.u32[ 0]);
+}
+
+static void
+HashTestBuffer(void)
+{
+    // NOTE(casey): Make a buffer with repeating numbers.  To ensure compatibility
+    // with older x64 chips, make sure to align the buffer!
+    int Size = 16000;
+    char *Buffer = (char *)aligned_alloc(MEOW_HASH_ALIGNMENT, Size);
+    for(int Index = 0;
+        Index < Size;
+        ++Index)
+    {
+        Buffer[Index] = (char)Index;
+    }
+    
+    // NOTE(casey): Ask Meow for the hash
+    meow_hash Hash = MeowHash(0, Size, Buffer);
+    
+    // NOTE(casey): Extract example smaller hash sizes you might want:
+    __m128i Hash128 = Hash.u128;
+    long long unsigned Hash64 = Hash.u64[0];
+    int unsigned Hash32 = Hash.u32[0];
+    
+    // NOTE(casey): Print the hash
+    printf("  Hash of a test buffer:\n");
+    PrintHash(Hash);
+    
+    free(Buffer);
+}
+
+static void
+HashOneFile(char *FilenameA)
+{
+    // NOTE(casey): Load the file
+    entire_file A = ReadEntireFile(FilenameA);
+    if(A.Contents)
+    {
+        // NOTE(casey): Ask Meow for the hash
+        meow_hash HashA = MeowHash(0, A.Size, A.Contents);
+        
+        // NOTE(casey): Print the hash
+        printf("  Hash of \"%s\":\n", FilenameA);
+        PrintHash(HashA);
+    }
+    
+    FreeEntireFile(&A);
+}
+
+static void
+CompareTwoFiles(char *FilenameA, char *FilenameB)
+{
+    // NOTE(casey): Load both files
+    entire_file A = ReadEntireFile(FilenameA);
+    entire_file B = ReadEntireFile(FilenameB);
+    if(A.Contents && B.Contents)
+    {
+        // NOTE(casey): Hash both files
+        meow_hash HashA = MeowHash(0, A.Size, A.Contents);
+        meow_hash HashB = MeowHash(0, B.Size, B.Contents);
+        
+        // NOTE(casey): Check for match
+        int HashesMatch = MeowHashesAreEqual(HashA, HashB);
+        int FilesMatch = ((A.Size == B.Size) && (memcmp(A.Contents, B.Contents, A.Size) == 0));
+        
+        // NOTE(casey): Print the result
+        if(HashesMatch && FilesMatch)
+        {
+            printf("Files \"%s\" and \"%s\" are the same:\n", FilenameA, FilenameB);
+            PrintHash(HashA);
+        }
+        else if(FilesMatch)
+        {
+            printf("MEOW HASH FAILURE: Files match but hashes don't!\n");
+            printf("  Hash of \"%s\":\n", FilenameA);
+            PrintHash(HashA);
+            printf("  Hash of \"%s\":\n", FilenameB);
+            PrintHash(HashB);
+        }
+        else if(HashesMatch)
+        {
+            printf("MEOW HASH FAILURE: Hashes match but files don't!\n");
+            printf("  Hash of both \"%s\" and \"%s\":\n", FilenameA, FilenameB);
+            PrintHash(HashA);
+        }
+        else
+        {
+            printf("Files \"%s\" and \"%s\" are different:\n", FilenameA, FilenameB);
+            printf("  Hash of \"%s\":\n", FilenameA);
+            PrintHash(HashA);
+            printf("  Hash of \"%s\":\n", FilenameB);
+            PrintHash(HashB);
+        }
+    }
+    
+    FreeEntireFile(&A);
+    FreeEntireFile(&B);
+}
+
+//
+// NOTE(casey): That's it!  Everything else below here is just boilerplate for starting up
+// and loading files with the C runtime library.
 //
 
-#include <stdio.h>
-
-int main(int ArgCount, char **Args)
+int
+main(int ArgCount, char **Args)
 {
-    printf("meow_example.cpp - basic usage example of the Meow hash\n");
+    // NOTE(casey): Print the banner
+    printf("meow_example %s - basic usage example of the Meow hash\n", MEOW_HASH_VERSION_NAME);
     printf("(C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)\n");
     printf("See https://mollyrocket.com/meowhash for details.\n");
     printf("\n");
@@ -74,39 +219,77 @@ int main(int ArgCount, char **Args)
     int BitWidth = MeowHashSpecializeForCPU();
     printf("Using %u-bit Meow implementation\n", BitWidth);
     
-    // NOTE(casey): Make something random to hash
-    int Size = 16000;
-    char *Buffer = (char *)malloc(Size);
-    for(int Index = 0;
-        Index < Size;
-        ++Index)
+    // NOTE(casey): Look at our arguments to decide which example to run
+    if(ArgCount < 2)
     {
-        Buffer[Index] = (char)Index;
+        HashTestBuffer();
+    }
+    else if(ArgCount == 2)
+    {
+        HashOneFile(Args[1]);
+    }
+    else if(ArgCount == 3)
+    {
+        CompareTwoFiles(Args[1], Args[2]);
+    }
+    else
+    {
+        printf("Usage:\n");
+        printf("%s - hash a test buffer\n", Args[0]);
+        printf("%s [filename] - hash the contents of [filename]\n", Args[0]);
+        printf("%s [filename0] [filename1] - hash the contents of [filename0] and [filename1] and compare them\n", Args[0]);
     }
     
-    // NOTE(casey): Hash away!
-    meow_lane Hash = MeowHash(0, Size, Buffer);
-    
-    // NOTE(casey): Extract example smaller hash sizes you might want:
-    __m128i Hash128 = Hash.L0;
-    long long unsigned Hash64 = Hash.Sub[0];
-    int unsigned Hash32 = Hash.Sub32[0];
-    
-    // NOTE(casey): Print the entire 512-bit hash value using the 32-bit accessor
-    // (since 64-bit printf is spec'd horribly)
-    for(int Offset = 0;
-        Offset < 16;
-        Offset += 8)
-    {
-        printf("\n    %08X-%08X-%08X-%08X %08X-%08X-%08X-%08X",
-               Hash.Sub32[15 - Offset],
-               Hash.Sub32[14 - Offset],
-               Hash.Sub32[13 - Offset],
-               Hash.Sub32[12 - Offset],
-               Hash.Sub32[11 - Offset],
-               Hash.Sub32[10 - Offset],
-               Hash.Sub32[9 - Offset],
-               Hash.Sub32[8 - Offset]);
-    }
-    printf("\n");
+    return(0);
 }
+
+static entire_file
+ReadEntireFile(char *Filename)
+{
+    entire_file Result = {};
+    
+    FILE *File = fopen(Filename, "rb");
+    if(File)
+    {
+        fseek(File, 0, SEEK_END);
+        Result.Size = ftell(File);
+        fseek(File, 0, SEEK_SET);
+
+        // NOTE(casey): To ensure compatibility with older x64 chips, make sure to align the buffer!
+        Result.Contents = aligned_alloc(MEOW_HASH_ALIGNMENT, Result.Size);
+        if(Result.Contents)
+        {
+            if(Result.Size)
+            {
+                fread(Result.Contents, Result.Size, 1, File);
+            }
+        }
+        else
+        {
+            Result.Contents = 0;
+            Result.Size = 0;
+        }
+        
+        fclose(File);
+    }
+    else
+    {
+        printf("ERROR: Unable to load \"%s\"\n", Filename);
+    }
+   
+    
+    return(Result);
+}
+
+static void
+FreeEntireFile(entire_file *File)
+{
+    if(File->Contents)
+    {
+        free(File->Contents);
+        File->Contents = 0;
+    }
+    
+    File->Size = 0;
+}
+

--- a/meow_hash.h
+++ b/meow_hash.h
@@ -8,17 +8,17 @@
    ========================================================================
    
    zlib License
-
+   
    (C) Copyright 2018 Molly Rocket, Inc.
-
+   
    This software is provided 'as-is', without any express or implied
    warranty.  In no event will the authors be held liable for any damages
    arising from the use of this software.
-
+   
    Permission is granted to anyone to use this software for any purpose,
    including commercial applications, and to alter it and redistribute it
    freely, subject to the following restrictions:
-
+   
    1. The origin of this software must not be misrepresented; you must not
       claim that you wrote the original software. If you use this software
       in a product, an acknowledgment in the product documentation would be
@@ -26,13 +26,13 @@
    2. Altered source versions must be plainly marked as such, and must not be
       misrepresented as being the original software.
    3. This notice may not be removed or altered from any source distribution.
-
+   
    ========================================================================
    
    FAQ
    
    Q: What is it?
-   A: Meow is a 512-bit non-cryptographic hash that operates at high speeds
+   A: Meow is a 128-bit non-cryptographic hash that operates at high speeds
       on x64 processors.  It is designed to be truncatable to 256, 128, 64,
       and 32-bit hash values and still retain good collision resistance.
       
@@ -41,11 +41,11 @@
       block deduplication or file verification.  As of its publication in
       October of 2018, it was the fastest hash in the smhasher suite by
       a factor of 3, but it still passes all smhasher tests and has not
-      yet produced any spurious collisions in practical deployment as compared
-      to a baseline of SHA-1.  It is also designed to get faster with age:
-      it already contains 256-wide and 512-wide hash-equivalent versions
-      that can be enabled for potentially 4x faster performance on future
-      VAES x64 chips when they are available.
+      yet produced any spurious collisions in practical deployment as
+      compared to a baseline of SHA-1.  It is also designed to get faster
+      with age: it already contains 256-wide and 512-wide hash-equivalent
+      versions that can be enabled for potentially 4x faster performance
+      on future VAES x64 chips when they are available.
       
    Q: What is it BAD for?
    A: Anything security-related.  It is not designed for security and has
@@ -60,11 +60,11 @@
    Q: Who wrote it and why?
    A: It was written by Casey Muratori (https://caseymuratori.com) for use
       in processing large-footprint assets for the game 1935
-      (https://molly1935.com).  The original system used an SHA-1 hash (which
-      is not designed for speed), and so to eliminate hashing bottlenecks
-      in the pipeline, the Meow hash was designed to produce equivalent
-      quality 256-bit hash values as a drop-in replacement that would take
-      a fraction of the CPU time.
+      (https://molly1935.com).  The original system used an SHA-1 hash
+      (which is not designed for speed), and so to eliminate hashing
+      bottlenecks in the pipeline, the Meow hash was designed to produce
+      equivalent quality 256-bit hash values as a drop-in replacement that
+      would take a fraction of the CPU time.
       
    Q: Why is it called the "Meow hash"?
    A: It was created while Meow the Infinite (https://meowtheinfinite.com)
@@ -101,33 +101,55 @@
    very least, you will want to make a thunk call that wraps the Meow hash
    with a conversion to your preferred 128/256/512-bit type.
    
-   By default, only the 128-bit wide, AES-NI version of the hash will
-   be compiled, because as of this publication, only the very latest
-   versions of most compilers can compile VAES code.  To enable the VAES
-   versions, you must use #defines:
+   If your compiler is older, and has trouble compiling code for AVX-512,
+   you can turn off the AVX-512 paths in Meow hash with a #define:
    
-       #define MEOW_HASH_256 // Enables 256-wide VAES version (MeowHash2)
-       #define MEOW_HASH_512 // Enables 512-wide VAES version (MeowHash4)
-       #include "meow_hash.h"
+       #define MEOW_HASH_AVX512 0
        
+   You can place this before you include meow_hash.h, or you can put
+   it in the compiler options for your compiler to define it automatically.
+   
+   If you need Meow to use different types than the default for u8, u32,
+   u64, and
+   
+   **** VERY IMPORTANT COMPILATION NOTE ****
+   
+   Meow uses the AESDEC instruction, which comes in two flavors:
+   SSE (aesdec) and AVX (vaesdec).  If you are compiling _with_ AVX support,
+   your compiler will probably emit the AVX variant, which means your code
+   WILL NOT RUN on computers that do not have AVX.  If you need to deploy
+   this hash on computers that do not have AVX, you must take care to
+   TURN OFF support for AVX in your compiler for the file that includes
+   the Meow hash!
+   
    ========================================================================
    
    USAGE
    
    For a complete working example, see meow_example.cpp.
    
-   To hash a block of data, call a MeowHash implementation:
+   In order to use the Meow hash, you must have x64 intrinsics defined.
+   This requires including a compiler-specific intrinsics file, such as:
    
+       #ifdef _MSC_VER
        #include <intrin.h>
+       #else
+       #include <x86intrin.h>
+       #endif
+       
+   Once you have intrinsics defined, to hash a block of data,
+   call a MeowHash implementation:
+   
        #include "meow_hash.h"
+       
+       // NOTE(casey): Source MUST be aligned to MEOW_HASH_ALIGNMENT
+       // if you are not compiling for platforms with AVX support!
        
        // Always available
        meow_lane MeowHash1(u64 Seed, u64 Len, void *Source);
        
-       // Available only if you #define MEOW_HASH_256
+       // Available only when compiling with AVX extensions
        meow_lane MeowHash2(u64 Seed, u64 Len, void *Source);
-       
-       // Available only if you #define MEOW_HASH_512
        meow_lane MeowHash4(u64 Seed, u64 Len, void *Source);
        
    MeowHash1 is 128-bit wide AES-NI.  MeowHash2 is 256-bit wide VAES.
@@ -136,227 +158,657 @@
    are for future use and internal x64 vendor testing.
    
    Calling MeowHash* with a seed, length, and source pointer invokes the
-   hash and returns a meow_lane union which contains the 512-bit result
-   accessible in a number of ways (u64[8], _m128i[4], _m256i[2],
-   and _m512i).  From there you can pull out what you want and discard the
-   rest, as the Meow hash is designed to produce high-quality hashes
-   when truncated down to anything 32 bits or greater.
-   
+   hash and returns a meow_lane union which contains the 128-bit result
+   accessible in a number of ways (u32[4], u64[2], _m128i).  From there
+   you can pull out what you want and discard the rest, as the Meow hash
+   is designed to produce high-quality hashes when truncated down to
+   anything 32 bits or greater.
+ 
    Since no currently available CPUs can run MeowHash2 or MeowHash4,
    it is not recommended that you include them in your code, because
    they literally _cannot_ be tested.  Once CPUs are available that
    can run them, you can include them and use a probing function
    to see if they can be used at startup, as shown in meow_example.cpp.
    
+   **** VERY IMPORTANT PROGRAMMING NOTE ****
+   
+   If you are compiling with AES-NI (not AVX), the source pointer to
+   MeowHash1 _must_ be aligned to the byte boundary specified by the
+   #define MEOW_HASH_ALIGNMENT, or Meow hash may fault with an
+   unaligned load.
+   
+   Because MeowHash2 and MeowHash4 are AVX-512 only, they do not have
+   these limitations, because they _cannot_ be compiled in non-AVX
+   modes.  So if you can run MeowHash2 and MeowHash4 at all, you can
+   run them on unaligned buffers just fine.
+   
+   TL;DR: If you don't know what AES-NI, VAES, VEX, etc. are, then just
+   always align your buffers :)  It's not hard to do, and it will
+   avoid you accidentally shipping code that crashes with unaligned
+   load exceptions.
+   
    ======================================================================== */
 
-#if defined(MEOW_HASH_SPECIALIZED)
+//
+// NOTE(casey): This version is EXPERIMENTAL.  The Meow hash is still
+// undergoing testing and finalization.
+//
+// **** EXPECT HASHES/APIs TO CHANGE UNTIL THE VERSION NUMBER HITS 1.0. ****
+//
+// You have been warned
+//
 
-static meow_lane
-MEOW_HASH_SPECIALIZED(meow_u64 Seed, meow_u64 Len, void *SourceInit)
+//
+// NOTE(casey): There is a lot of manually expanded stuff in this code.
+// It's not because I like typing things ad infinitum.  It's because compilers
+// still aren't good enough to get the machine code right if you start
+// adding layers of indirection.  Believe me, I like copying the same line
+// 16 times and typing S0 through SF about as much as you do, but at the
+// moment, if you want the code to be fast across many different compilers,
+// it can't be helped.
+//
+
+#if !defined(MEOW_HASH_AVX512)
+#define MEOW_HASH_AVX512 0
+#endif
+
+#if !defined(MEOW_HASH_TYPES)
+#define meow_u8 char unsigned
+#define meow_u32 int unsigned
+#define meow_u64 long long unsigned
+#define meow_u128 __m128i
+#if MEOW_HASH_AVX512
+#define meow_u256 __m256i
+#define meow_u512 __m512i
+#endif
+#define MEOW_HASH_TYPES
+#endif
+
+#define MEOW_HASH_VERSION 2
+#define MEOW_HASH_VERSION_NAME "0.2/Ragdoll"
+#define MEOW_HASH_ALIGNMENT 128
+#define MEOW_HASH_MACROBLOCK_COUNT 4096
+#define MEOW_HASH_MACROBLOCK_SIZE (MEOW_HASH_MACROBLOCK_COUNT << MEOW_HASH_BLOCK_SIZE_SHIFT)
+#define MEOW_HASH_BLOCK_SIZE_SHIFT 8
+
+typedef union meow_hash
 {
-    // NOTE(casey): The initialization vector follows falkhash's lead and uses the seed twice, but the second time
-    // the length plus one is added to differentiate.  This seemed sensible, but I haven't thought too hard about this,
-    // there may be better things to use as an IV.
-    meow_lane IV;
-    IV.Sub[0] = IV.Sub[2] = IV.Sub[4] = IV.Sub[6] = Seed;
-    IV.Sub[1] = IV.Sub[3] = IV.Sub[5] = IV.Sub[7] = Seed + Len + 1;
+    meow_u128 u128;
+    meow_u64 u64[2];
+    meow_u32 u32[4];
+} meow_hash;
+
+typedef struct meow_source_blocks
+{
+    meow_u64 TotalLengthInBytes;
+    meow_u64 BlockCount;
+    meow_u64 MacroblockCount;
+    meow_u8 *Source;
+    meow_u8 *OverhangStart;
+
+    int Overhang;
+} meow_source_blocks;
+
+typedef struct meow_macroblock
+{
+    meow_u8 *Source;
+    int BlockCount;
+} meow_macroblock;
+
+typedef struct meow_macroblock_result
+{
+    meow_u128 S0;
+    meow_u128 S1;
+    meow_u128 S2;
+    meow_u128 S3;
+    meow_u128 S4;
+    meow_u128 S5;
+    meow_u128 S6;
+    meow_u128 S7;
+    meow_u128 S8;
+    meow_u128 S9;
+    meow_u128 SA;
+    meow_u128 SB;
+    meow_u128 SC;
+    meow_u128 SD;
+    meow_u128 SE;
+    meow_u128 SF;
+} meow_macroblock_result;
+
+typedef meow_macroblock_result meow_macroblock_op(int BlockCount, meow_u8 *Source);
+typedef meow_hash meow_hash_implementation(meow_u64 Seed, meow_u64 Len, void *SourceInit);
+
+//
+// NOTE(casey): "Fast" comparison (using SSE)
+//
+static int
+MeowHashesAreEqual(meow_hash A, meow_hash B)
+{
+    int Mask = _mm_movemask_epi8(_mm_cmpeq_epi8(A.u128, B.u128));
+    int Result = (Mask == 0xFFFF);
+    return(Result);
+}
+
+//
+// NOTE(casey): Macro-block based hashing, for multithreading very large hashes,
+// due to prodding by speed demon Jeff Roberts of RAD Game Tools, Inc. (https://radgametools.com)
+//
+
+static meow_source_blocks
+MeowSourceBlocksFor(meow_u64 TotalLengthInBytes, void *Source)
+{
+    meow_source_blocks Result;
     
-    // NOTE(casey): Initialize all 16 streams with the initialization vector
-    meow_lane S0123 = IV;
-    meow_lane S4567 = IV;
-    meow_lane S89AB = IV;
-    meow_lane SCDEF = IV;
+    Result.TotalLengthInBytes = TotalLengthInBytes;
+    Result.BlockCount = (TotalLengthInBytes >> MEOW_HASH_BLOCK_SIZE_SHIFT);
+    Result.MacroblockCount = (Result.BlockCount + MEOW_HASH_MACROBLOCK_COUNT - 1) / MEOW_HASH_MACROBLOCK_COUNT;
+    Result.Source = (meow_u8 *)Source;
     
-    // NOTE(casey): Handle as many full 256-byte blocks as possible
-    meow_u8 *Source = (meow_u8 *)SourceInit;
-    meow_u64 BlockCount = (Len >> 8);
-    Len -= (BlockCount << 8);
-    while(BlockCount--)
+    Result.Overhang = (int)(TotalLengthInBytes - (Result.BlockCount << MEOW_HASH_BLOCK_SIZE_SHIFT));
+    Result.OverhangStart = Result.Source + (Result.TotalLengthInBytes - Result.Overhang);
+    
+    return(Result);
+}
+
+static meow_macroblock
+MeowGetMacroblock(meow_source_blocks volatile *Blocks, meow_u64 Index)
+{
+    meow_u64 Offset = (Index * MEOW_HASH_MACROBLOCK_SIZE);
+    meow_u64 BlockCount = ((Blocks->TotalLengthInBytes - Offset) >> MEOW_HASH_BLOCK_SIZE_SHIFT);
+    
+    meow_macroblock Result;
+    Result.Source = Blocks->Source + Offset;
+    Result.BlockCount = MEOW_HASH_MACROBLOCK_COUNT;
+    if(Result.BlockCount > BlockCount)
     {
-        AESLoad(S0123, Source);
-        AESLoad(S4567, Source + 64);
-        AESLoad(S89AB, Source + 128);
-        AESLoad(SCDEF, Source + 192);
-        Source += (1 << 8);
+        Result.BlockCount = (int)BlockCount;
     }
     
-    // NOTE(casey): If residual data remains, hash one final 256-byte block padded with the initialization vector
-    if(Len)
+    return(Result);
+}
+
+static void
+MeowHashMerge(meow_macroblock_result *A, meow_macroblock_result *B)
+{
+    A->S0 = _mm_aesdec_si128(A->S0, B->S0);
+    A->S1 = _mm_aesdec_si128(A->S1, B->S1);
+    A->S2 = _mm_aesdec_si128(A->S2, B->S2);
+    A->S3 = _mm_aesdec_si128(A->S3, B->S3);
+    A->S4 = _mm_aesdec_si128(A->S4, B->S4);
+    A->S5 = _mm_aesdec_si128(A->S5, B->S5);
+    A->S6 = _mm_aesdec_si128(A->S6, B->S6);
+    A->S7 = _mm_aesdec_si128(A->S7, B->S7);
+    A->S8 = _mm_aesdec_si128(A->S8, B->S8);
+    A->S9 = _mm_aesdec_si128(A->S9, B->S9);
+    A->SA = _mm_aesdec_si128(A->SA, B->SA);
+    A->SB = _mm_aesdec_si128(A->SB, B->SB);
+    A->SC = _mm_aesdec_si128(A->SC, B->SC);
+    A->SD = _mm_aesdec_si128(A->SD, B->SD);
+    A->SE = _mm_aesdec_si128(A->SE, B->SE);
+    A->SF = _mm_aesdec_si128(A->SF, B->SF);
+}
+
+static meow_hash
+MeowHashFinish(meow_macroblock_result *State, meow_u64 Seed, meow_u64 TotalLengthInBytes, int Overhang, meow_u8 *Source)
+{
+    meow_u128 S0 = State->S0;
+    meow_u128 S1 = State->S1;
+    meow_u128 S2 = State->S2;
+    meow_u128 S3 = State->S3;
+    meow_u128 S4 = State->S4;
+    meow_u128 S5 = State->S5;
+    meow_u128 S6 = State->S6;
+    meow_u128 S7 = State->S7;
+    meow_u128 S8 = State->S8;
+    meow_u128 S9 = State->S9;
+    meow_u128 SA = State->SA;
+    meow_u128 SB = State->SB;
+    meow_u128 SC = State->SC;
+    meow_u128 SD = State->SD;
+    meow_u128 SE = State->SE;
+    meow_u128 SF = State->SF;
+    
+    // NOTE(casey): Handle as many full 128-bit lanes as possible
+    switch(Overhang >> 4)
     {
-        // TODO(casey): Can this just be zeroes?
-        meow_lane Partial[] = {IV, IV, IV, IV};
-        meow_u8 *Dest = (meow_u8 *)Partial;
-        while(Len--)
+        case 15: SE = _mm_aesdec_si128(SE, *(meow_u128 *)(Source + 224));
+        case 14: SD = _mm_aesdec_si128(SD, *(meow_u128 *)(Source + 208));
+        case 13: SC = _mm_aesdec_si128(SC, *(meow_u128 *)(Source + 192));
+        case 12: SB = _mm_aesdec_si128(SB, *(meow_u128 *)(Source + 176));
+        case 11: SA = _mm_aesdec_si128(SA, *(meow_u128 *)(Source + 160));
+        case 10: S9 = _mm_aesdec_si128(S9, *(meow_u128 *)(Source + 144));
+        case  9: S8 = _mm_aesdec_si128(S8, *(meow_u128 *)(Source + 128));
+        case  8: S7 = _mm_aesdec_si128(S7, *(meow_u128 *)(Source + 112));
+        case  7: S6 = _mm_aesdec_si128(S6, *(meow_u128 *)(Source + 96));
+        case  6: S5 = _mm_aesdec_si128(S5, *(meow_u128 *)(Source + 80));
+        case  5: S4 = _mm_aesdec_si128(S4, *(meow_u128 *)(Source + 64));
+        case  4: S3 = _mm_aesdec_si128(S3, *(meow_u128 *)(Source + 48));
+        case  3: S2 = _mm_aesdec_si128(S2, *(meow_u128 *)(Source + 32));
+        case  2: S1 = _mm_aesdec_si128(S1, *(meow_u128 *)(Source + 16));
+        case  1: S0 = _mm_aesdec_si128(S0, *(meow_u128 *)(Source));
+        default:;
+    }
+
+    // NOTE(casey): Handle residual by padding to the nearest 16-byte boundary
+    // This is made more complicated due to the overlapped load trick used
+    // in the non-macroblock version of the hash.
+    if(Overhang & 0xF)
+    {
+        if(TotalLengthInBytes >= 16)
+        {
+            Source += (Overhang - 16);
+            Overhang = 16;
+        }
+        else
+        {
+            Source += (Overhang & 0xF0);
+            Overhang &= 0xF;
+        }
+    
+        meow_u128 Partial = _mm_setzero_si128();
+        meow_u8 *Dest = (meow_u8 *)&Partial;
+        while(Overhang--)
         {
             *Dest++ = *Source++;
         }
 
-        meow_u8 *P = (meow_u8 *)Partial;
-        AESMerge(S0123, Partial[0]);
-        AESMerge(S4567, Partial[1]);
-        AESMerge(S89AB, Partial[2]);
-        AESMerge(SCDEF, Partial[3]);
+        SF = _mm_aesdec_si128(SF, Partial);
     }
     
     // NOTE(casey): Combine the 16 streams into a single hash to spread the bits out evenly
-    meow_lane R0 = IV;
-    AESRotate(R0, S0123);
-    AESRotate(R0, S4567);
-    AESRotate(R0, S89AB);
-    AESRotate(R0, SCDEF);
+    meow_u128 M0 = S7;
+    M0 = _mm_aesdec_si128(M0, SA);
+    M0 = _mm_aesdec_si128(M0, S4);
+    M0 = _mm_aesdec_si128(M0, S5);
+    M0 = _mm_aesdec_si128(M0, SC);
+    M0 = _mm_aesdec_si128(M0, S8);
+    M0 = _mm_aesdec_si128(M0, S0);
+    M0 = _mm_aesdec_si128(M0, S1);
+    M0 = _mm_aesdec_si128(M0, S9);
+    M0 = _mm_aesdec_si128(M0, SD);
+    M0 = _mm_aesdec_si128(M0, S2);
+    M0 = _mm_aesdec_si128(M0, S6);
+    M0 = _mm_aesdec_si128(M0, SE);
+    M0 = _mm_aesdec_si128(M0, S3);
+    M0 = _mm_aesdec_si128(M0, SB);
+    M0 = _mm_aesdec_si128(M0, SF);
     
-    AESRotate(R0, S0123);
-    AESRotate(R0, S4567);
-    AESRotate(R0, S89AB);
-    AESRotate(R0, SCDEF);
+    // NOTE(casey): The mixing vector follows falkhash's lead and uses the seed twice, but the second time
+    // the length plus one is added to differentiate.  This seemed sensible, but I haven't thought too hard about this,
+    // there may be better things to use as a mixer.
+    meow_u128 Mixer = _mm_set_epi64x(Seed + TotalLengthInBytes + 1, Seed - TotalLengthInBytes);
     
-    AESRotate(R0, S0123);
-    AESRotate(R0, S4567);
-    AESRotate(R0, S89AB);
-    AESRotate(R0, SCDEF);
+    // NOTE(casey): Repeat AES thrice to ensure diffusion to all 128 bits (using the Mixer, so the seed and length come in)
+    M0 = _mm_aesdec_si128(M0, Mixer);
+    M0 = _mm_aesdec_si128(M0, Mixer);
+    M0 = _mm_aesdec_si128(M0, Mixer);
     
-    AESRotate(R0, S0123);
-    AESRotate(R0, S4567);
-    AESRotate(R0, S89AB);
-    AESRotate(R0, SCDEF);
+    meow_hash Result;
+    Result.u128 = M0;
     
-    // NOTE(casey): Repeat AES enough times to ensure diffusion to all bits in each 128-bit lane
-    AESMerge(R0, IV);
-    AESMerge(R0, IV);
-    AESMerge(R0, IV);
-    AESMerge(R0, IV);
-    AESMerge(R0, IV);
-    
-    return(R0);
+    return(Result);
 }
 
-#undef AESLoad
-#undef AESMerge
-#undef AESRotate
-#undef MEOW_HASH_SPECIALIZED
-
-#else
-
-#if !defined(MEOW_HASH_TYPES)
-#define MEOW_HASH_VERSION 1
-#define MEOW_HASH_VERSION_NAME "0.1 Alpha"
-#define meow_u8 char unsigned
-#define meow_u32 int unsigned
-#define meow_u64 long long unsigned
-
-union meow_lane
+static meow_hash
+MeowHashViaOp(meow_macroblock_op *Op, meow_u64 Seed, meow_u64 TotalLengthInBytes, void *SourceInit)
 {
-#if defined(MEOW_HASH_512)
-    __m512i Q0;
-#endif
-
-#if defined(MEOW_HASH_256)
-    struct
+    // NOTE(casey): Initialize all 16 streams to 0
+    meow_macroblock_result Group = {};
+    
+    // NOTE(casey): Reserve some space for individual macroblock hashes
+    meow_macroblock_result SubGroup;
+    
+    // NOTE(casey): Hash 256-byte blocks, broken up into 1-megabyte macroblocks
+    // The 256-byte blocks are to ensure good pipelining on future AVX-512 chips.
+    // The 1-megabyte macroblocks are to allow (other, distributed) implementations
+    // to hash asynchronously across many cores and assemble at the end.
+    int First = true;
+    meow_source_blocks Counts = MeowSourceBlocksFor(TotalLengthInBytes, SourceInit);
+    meow_u8 *Source = Counts.Source;
+    meow_u64 BlockCount = Counts.BlockCount;
+    meow_u64 MacroblockCount = Counts.MacroblockCount;
+    while(MacroblockCount--)
     {
-        __m256i D0;
-        __m256i D1;
-    };
-#endif
-
-    struct
-    {
-        __m128i L0;
-        __m128i L1;
-        __m128i L2;
-        __m128i L3;
-    };
+        // NOTE(casey): Determine how many blocks are in this macroblock
+        int SubBlockCount = MEOW_HASH_MACROBLOCK_COUNT;
+        if(SubBlockCount > BlockCount)
+        {
+            SubBlockCount = (int)BlockCount;
+        }
+        
+        if(First)
+        {
+            // NOTE(casey): To prevent mixing in extra 0's, we _start_ with the initial group,
+            // and then merge the hash from there.  This makes the routine clumsier, but probably
+            // makes the hash better, so we grin and bear it.
+            Group = Op(SubBlockCount, Source);
+            First = false;
+        }
+        else
+        {
+            // NOTE(casey): Hash this macroblock's sub-hash
+            SubGroup = Op(SubBlockCount, Source);
+            
+            // NOTE(casey): Merge it in to the existing hash
+            MeowHashMerge(&Group, &SubGroup);
+        }
     
-    meow_u64 Sub[8];
-    meow_u32 Sub32[16];
-};
-
-typedef meow_lane meow_hash_implementation(meow_u64 Seed, meow_u64 Len, void *SourceInit);
-
-#define MEOW_HASH_TYPES
-#endif
-
-static void
-MeowAESRotate128x4(meow_lane &A, meow_lane &B)
-{
-    A.L0 = _mm_aesdec_si128(A.L0, B.L0);
-    A.L1 = _mm_aesdec_si128(A.L1, B.L1);
-    A.L2 = _mm_aesdec_si128(A.L2, B.L2);
-    A.L3 = _mm_aesdec_si128(A.L3, B.L3);
-
-    __m128i Temp = B.L0;
-    B.L0 = B.L1;
-    B.L1 = B.L2;
-    B.L2 = B.L3;
-    B.L3 = Temp;
+        // NOTE(casey): Advance to the next macroblock
+        BlockCount -= SubBlockCount;
+        Source += (SubBlockCount << MEOW_HASH_BLOCK_SIZE_SHIFT);
+    }
+    
+    // NOTE(casey): Hash any residual data and finalize
+    meow_hash Result = MeowHashFinish(&Group, Seed, Counts.TotalLengthInBytes, Counts.Overhang, Source);
+    
+    return(Result);
 }
 
-// NOTE(casey): 128-wide AES-NI Meow (maximum of 16 bytes/clock)
-#define MEOW_HASH_SPECIALIZED MeowHash1
-#define AESLoad(S, From) \
-S.L0 = _mm_aesdec_si128(S.L0, *(__m128i *)(From)); \
-S.L1 = _mm_aesdec_si128(S.L1, *(__m128i *)(From + 16)); \
-S.L2 = _mm_aesdec_si128(S.L2, *(__m128i *)(From + 32)); \
-S.L3 = _mm_aesdec_si128(S.L3, *(__m128i *)(From + 48))
-#define AESMerge(A, B) \
-A.L0 = _mm_aesdec_si128(A.L0, B.L0); \
-A.L1 = _mm_aesdec_si128(A.L1, B.L1); \
-A.L2 = _mm_aesdec_si128(A.L2, B.L2); \
-A.L3 = _mm_aesdec_si128(A.L3, B.L3)
-#define AESRotate MeowAESRotate128x4
-#include "meow_hash.h"
-
-// NOTE(casey): 256-wide VAES Meow (maximum of 32 bytes/clock)
-#if defined(MEOW_HASH_256)
-static void
-MeowAESRotate256x2(meow_lane &A, meow_lane &B)
+static meow_macroblock_result
+MeowHashMergeArray(meow_u64 MacroBlockCount, meow_macroblock_result *MacroBlockHashes)
 {
-    A.D0 = _mm256_aesdec_epi128(A.D0, B.D0);
-    A.D1 = _mm256_aesdec_epi128(A.D1, B.D1);
-
-    // TODO(casey): This can be done with permutation instructions,
-    // but I will forgo implementing it that way until I have an
-    // actual CPU to test it on!
-    __m128i Temp = B.L0;
-    B.L0 = B.L1;
-    B.L1 = B.L2;
-    B.L2 = B.L3;
-    B.L3 = Temp;
+    meow_macroblock_result Result;
+    
+    if(MacroBlockCount > 0)
+    {
+        Result = MacroBlockHashes[0];
+        for(meow_u64 MacroBlockIndex = 1;
+            MacroBlockIndex < MacroBlockCount;
+            ++MacroBlockIndex)
+        {
+            MeowHashMerge(&Result, MacroBlockHashes + MacroBlockIndex);
+        }
+    }
+    else
+    {
+        // NOTE(casey): Do the nullification in two steps to support older compilers (MSVC 2012, etc.)
+        meow_macroblock_result NullGroup = {};
+        Result = NullGroup;
+    }
+    
+    return(Result);
 }
-#define MEOW_HASH_SPECIALIZED MeowHash2
-#define AESLoad(S, From) \
-S.D0 = _mm256_aesdec_epi128(S.D0, *(__m256i *)(From)); \
-S.D1 = _mm256_aesdec_epi128(S.D1, *(__m256i *)(From + 32))
-#define AESMerge(A, B) \
-A.D0 = _mm256_aesdec_epi128(A.D0, B.D0); \
-A.D1 = _mm256_aesdec_epi128(A.D1, B.D1)
-#define AESRotate MeowAESRotate256x2
-#include "meow_hash.h"
-#endif
 
-// NOTE(casey): 512-wide VAES Meow (maximum of 64 bytes/clock)
-#if defined(MEOW_HASH_512)
-static void
-MeowAESRotate512(meow_lane &A, meow_lane &B)
+//
+// NOTE(casey): 128-wide AES-NI Meow (maximum of 16 bytes/clock single threaded)
+//
+
+static meow_macroblock_result
+MeowHash1Op(int BlockCount, meow_u8 *Source)
 {
-    A.Q0 = _mm512_aesdec_epi128(A.Q0, B.Q0);
-
-    // TODO(casey): This rotate can be done with permutation instructions,
-    // but I will forgo implementing it that way until I have an
-    // actual CPU to test it on!
-    __m128i Temp = B.L0;
-    B.L0 = B.L1;
-    B.L1 = B.L2;
-    B.L2 = B.L3;
-    B.L3 = Temp;
+    meow_u128 S0 = _mm_setzero_si128();
+    meow_u128 S1 = _mm_setzero_si128();
+    meow_u128 S2 = _mm_setzero_si128();
+    meow_u128 S3 = _mm_setzero_si128();
+    meow_u128 S4 = _mm_setzero_si128();
+    meow_u128 S5 = _mm_setzero_si128();
+    meow_u128 S6 = _mm_setzero_si128();
+    meow_u128 S7 = _mm_setzero_si128();
+    meow_u128 S8 = _mm_setzero_si128();
+    meow_u128 S9 = _mm_setzero_si128();
+    meow_u128 SA = _mm_setzero_si128();
+    meow_u128 SB = _mm_setzero_si128();
+    meow_u128 SC = _mm_setzero_si128();
+    meow_u128 SD = _mm_setzero_si128();
+    meow_u128 SE = _mm_setzero_si128();
+    meow_u128 SF = _mm_setzero_si128();
+    
+    while(BlockCount--)
+    {
+        S0 = _mm_aesdec_si128(S0, *(meow_u128 *)(Source));
+        S1 = _mm_aesdec_si128(S1, *(meow_u128 *)(Source + 16));
+        S2 = _mm_aesdec_si128(S2, *(meow_u128 *)(Source + 32));
+        S3 = _mm_aesdec_si128(S3, *(meow_u128 *)(Source + 48));
+        S4 = _mm_aesdec_si128(S4, *(meow_u128 *)(Source + 64));
+        S5 = _mm_aesdec_si128(S5, *(meow_u128 *)(Source + 80));
+        S6 = _mm_aesdec_si128(S6, *(meow_u128 *)(Source + 96));
+        S7 = _mm_aesdec_si128(S7, *(meow_u128 *)(Source + 112));
+        S8 = _mm_aesdec_si128(S8, *(meow_u128 *)(Source + 128));
+        S9 = _mm_aesdec_si128(S9, *(meow_u128 *)(Source + 144));
+        SA = _mm_aesdec_si128(SA, *(meow_u128 *)(Source + 160));
+        SB = _mm_aesdec_si128(SB, *(meow_u128 *)(Source + 176));
+        SC = _mm_aesdec_si128(SC, *(meow_u128 *)(Source + 192));
+        SD = _mm_aesdec_si128(SD, *(meow_u128 *)(Source + 208));
+        SE = _mm_aesdec_si128(SE, *(meow_u128 *)(Source + 224));
+        SF = _mm_aesdec_si128(SF, *(meow_u128 *)(Source + 240));
+        
+        Source += (1 << MEOW_HASH_BLOCK_SIZE_SHIFT);
+    }
+    
+    meow_macroblock_result Result;
+    Result.S0 = S0;
+    Result.S1 = S1;
+    Result.S2 = S2;
+    Result.S3 = S3;
+    Result.S4 = S4;
+    Result.S5 = S5;
+    Result.S6 = S6;
+    Result.S7 = S7;
+    Result.S8 = S8;
+    Result.S9 = S9;
+    Result.SA = SA;
+    Result.SB = SB;
+    Result.SC = SC;
+    Result.SD = SD;
+    Result.SE = SE;
+    Result.SF = SF;
+    
+    return(Result);
 }
-#define MEOW_HASH_SPECIALIZED MeowHash4
-#define AESLoad(S, From) \
-S.Q0 = _mm512_aesdec_epi128(S.Q0, *(__m512i *)(From))
-#define AESMerge(A, B) \
-A.Q0 = _mm512_aesdec_epi128(A.Q0, B.Q0);
-#define AESRotate MeowAESRotate512
-#include "meow_hash.h"
-#endif
+
+static meow_hash
+MeowHash1(meow_u64 Seed, meow_u64 TotalLengthInBytes, void *SourceInit)
+{
+    // NOTE(casey): For less than 16 bytes, we punt, because we can't guarantee we won't issue a bad load.
+    // For more than MEOW_HASH_MACROBLOCK_SIZE, we punt, because we want to support multithreading.
+    if((TotalLengthInBytes < 16) ||
+       (TotalLengthInBytes >= MEOW_HASH_MACROBLOCK_SIZE))
+    {
+        return(MeowHashViaOp(MeowHash1Op, Seed, TotalLengthInBytes, SourceInit));
+    }
+    
+    // NOTE(casey): Initialize all 16 streams to 0
+    meow_u128 S0 = _mm_setzero_si128();
+    meow_u128 S1 = _mm_setzero_si128();
+    meow_u128 S2 = _mm_setzero_si128();
+    meow_u128 S3 = _mm_setzero_si128();
+    meow_u128 S4 = _mm_setzero_si128();
+    meow_u128 S5 = _mm_setzero_si128();
+    meow_u128 S6 = _mm_setzero_si128();
+    meow_u128 S7 = _mm_setzero_si128();
+    meow_u128 S8 = _mm_setzero_si128();
+    meow_u128 S9 = _mm_setzero_si128();
+    meow_u128 SA = _mm_setzero_si128();
+    meow_u128 SB = _mm_setzero_si128();
+    meow_u128 SC = _mm_setzero_si128();
+    meow_u128 SD = _mm_setzero_si128();
+    meow_u128 SE = _mm_setzero_si128();
+    meow_u128 SF = _mm_setzero_si128();
+    
+    // NOTE(casey): Handle as many full 256-byte blocks as possible
+    meow_u8 *Source = (meow_u8 *)SourceInit;
+    int Len = (int)TotalLengthInBytes;
+    int BlockCount = (Len >> MEOW_HASH_BLOCK_SIZE_SHIFT);
+    Len -= (BlockCount << MEOW_HASH_BLOCK_SIZE_SHIFT);
+    while(BlockCount--)
+    {
+        S0 = _mm_aesdec_si128(S0, *(meow_u128 *)(Source));
+        S1 = _mm_aesdec_si128(S1, *(meow_u128 *)(Source + 16));
+        S2 = _mm_aesdec_si128(S2, *(meow_u128 *)(Source + 32));
+        S3 = _mm_aesdec_si128(S3, *(meow_u128 *)(Source + 48));
+        S4 = _mm_aesdec_si128(S4, *(meow_u128 *)(Source + 64));
+        S5 = _mm_aesdec_si128(S5, *(meow_u128 *)(Source + 80));
+        S6 = _mm_aesdec_si128(S6, *(meow_u128 *)(Source + 96));
+        S7 = _mm_aesdec_si128(S7, *(meow_u128 *)(Source + 112));
+        S8 = _mm_aesdec_si128(S8, *(meow_u128 *)(Source + 128));
+        S9 = _mm_aesdec_si128(S9, *(meow_u128 *)(Source + 144));
+        SA = _mm_aesdec_si128(SA, *(meow_u128 *)(Source + 160));
+        SB = _mm_aesdec_si128(SB, *(meow_u128 *)(Source + 176));
+        SC = _mm_aesdec_si128(SC, *(meow_u128 *)(Source + 192));
+        SD = _mm_aesdec_si128(SD, *(meow_u128 *)(Source + 208));
+        SE = _mm_aesdec_si128(SE, *(meow_u128 *)(Source + 224));
+        SF = _mm_aesdec_si128(SF, *(meow_u128 *)(Source + 240));
+        
+        Source += (1 << MEOW_HASH_BLOCK_SIZE_SHIFT);
+    }
+    
+    // NOTE(casey): Handle as many full 128-bit lanes as possible
+    switch(Len >> 4)
+    {
+        case 15: SE = _mm_aesdec_si128(SE, *(meow_u128 *)(Source + 224));
+        case 14: SD = _mm_aesdec_si128(SD, *(meow_u128 *)(Source + 208));
+        case 13: SC = _mm_aesdec_si128(SC, *(meow_u128 *)(Source + 192));
+        case 12: SB = _mm_aesdec_si128(SB, *(meow_u128 *)(Source + 176));
+        case 11: SA = _mm_aesdec_si128(SA, *(meow_u128 *)(Source + 160));
+        case 10: S9 = _mm_aesdec_si128(S9, *(meow_u128 *)(Source + 144));
+        case  9: S8 = _mm_aesdec_si128(S8, *(meow_u128 *)(Source + 128));
+        case  8: S7 = _mm_aesdec_si128(S7, *(meow_u128 *)(Source + 112));
+        case  7: S6 = _mm_aesdec_si128(S6, *(meow_u128 *)(Source + 96));
+        case  6: S5 = _mm_aesdec_si128(S5, *(meow_u128 *)(Source + 80));
+        case  5: S4 = _mm_aesdec_si128(S4, *(meow_u128 *)(Source + 64));
+        case  4: S3 = _mm_aesdec_si128(S3, *(meow_u128 *)(Source + 48));
+        case  3: S2 = _mm_aesdec_si128(S2, *(meow_u128 *)(Source + 32));
+        case  2: S1 = _mm_aesdec_si128(S1, *(meow_u128 *)(Source + 16));
+        case  1: S0 = _mm_aesdec_si128(S0, *(meow_u128 *)(Source));
+        default:;
+    }
+    
+    // NOTE(casey): Deal with individual bytes
+    // Many thanks to Fabien Giesen here for pointing out the overlapping load trick
+    if(Len & 0xF)
+    {
+        // NOTE(casey): This only works because we don't use this routine on buffers
+        // less than 16 bytes long (see top of function)
+        SF = _mm_aesdec_si128(SF, _mm_loadu_si128((meow_u128 *)(Source + Len - 16)));
+    }
+    
+    // NOTE(casey): Combine the 16 streams into a single hash to spread the bits out evenly
+    meow_u128 M0 = S7;
+    M0 = _mm_aesdec_si128(M0, SA);
+    M0 = _mm_aesdec_si128(M0, S4);
+    M0 = _mm_aesdec_si128(M0, S5);
+    M0 = _mm_aesdec_si128(M0, SC);
+    M0 = _mm_aesdec_si128(M0, S8);
+    M0 = _mm_aesdec_si128(M0, S0);
+    M0 = _mm_aesdec_si128(M0, S1);
+    M0 = _mm_aesdec_si128(M0, S9);
+    M0 = _mm_aesdec_si128(M0, SD);
+    M0 = _mm_aesdec_si128(M0, S2);
+    M0 = _mm_aesdec_si128(M0, S6);
+    M0 = _mm_aesdec_si128(M0, SE);
+    M0 = _mm_aesdec_si128(M0, S3);
+    M0 = _mm_aesdec_si128(M0, SB);
+    M0 = _mm_aesdec_si128(M0, SF);
+    
+    // NOTE(casey): The mixing vector follows falkhash's lead and uses the seed twice, but the second time
+    // the length plus one is added to differentiate.  This seemed sensible, but I haven't thought too hard about this,
+    // there may be better things to use as a mixer.
+    meow_u128 Mixer = _mm_set_epi64x(Seed + TotalLengthInBytes + 1, Seed - TotalLengthInBytes);
+    
+    // NOTE(casey): Repeat AES thrice to ensure diffusion to all 128 bits (using the Mixer, so the seed and length come in)
+    M0 = _mm_aesdec_si128(M0, Mixer);
+    M0 = _mm_aesdec_si128(M0, Mixer);
+    M0 = _mm_aesdec_si128(M0, Mixer);
+    
+    meow_hash Result;
+    Result.u128 = M0;
+    
+    return(Result);
+}
+
+#if MEOW_HASH_AVX512
+
+//
+// NOTE(casey): 256-wide VAES Meow (maximum of 32 bytes/clock single threaded)
+//
+
+static meow_macroblock_result
+MeowHash2Op(int BlockCount, meow_u8 *Source)
+{
+    meow_u256 S01 = _mm256_setzero_si256();
+    meow_u256 S23 = _mm256_setzero_si256();
+    meow_u256 S45 = _mm256_setzero_si256();
+    meow_u256 S67 = _mm256_setzero_si256();
+    meow_u256 S89 = _mm256_setzero_si256();
+    meow_u256 SAB = _mm256_setzero_si256();
+    meow_u256 SCD = _mm256_setzero_si256();
+    meow_u256 SEF = _mm256_setzero_si256();
+    
+    while(BlockCount--)
+    {
+        S01 = _mm256_aesdec_epi128(S01, *(meow_u256 *)(Source));
+        S23 = _mm256_aesdec_epi128(S23, *(meow_u256 *)(Source + 32));
+        
+        S45 = _mm256_aesdec_epi128(S45, *(meow_u256 *)(Source + 64));
+        S67 = _mm256_aesdec_epi128(S67, *(meow_u256 *)(Source + 96));
+        
+        S89 = _mm256_aesdec_epi128(S89, *(meow_u256 *)(Source + 128));
+        SAB = _mm256_aesdec_epi128(SAB, *(meow_u256 *)(Source + 160));
+        
+        SCD = _mm256_aesdec_epi128(SCD, *(meow_u256 *)(Source + 192));
+        SEF = _mm256_aesdec_epi128(SEF, *(meow_u256 *)(Source + 224));
+        
+        Source += (1 << MEOW_HASH_BLOCK_SIZE_SHIFT);
+    }
+    
+    meow_macroblock_result Result;
+    _mm256_store_si256((meow_u256 *)&Result.S0, S01);
+    _mm256_store_si256((meow_u256 *)&Result.S2, S23);
+    _mm256_store_si256((meow_u256 *)&Result.S4, S45);
+    _mm256_store_si256((meow_u256 *)&Result.S6, S67);
+    _mm256_store_si256((meow_u256 *)&Result.S8, S89);
+    _mm256_store_si256((meow_u256 *)&Result.SA, SAB);
+    _mm256_store_si256((meow_u256 *)&Result.SC, SCD);
+    _mm256_store_si256((meow_u256 *)&Result.SE, SEF);
+    
+    return(Result);
+}
+
+static meow_hash
+MeowHash2(meow_u64 Seed, meow_u64 TotalLengthInBytes, void *Source)
+{
+    // TODO(casey): Once we can test, do the optimized non-megabyte version for 256-bit
+    meow_hash Result = MeowHashViaOp(MeowHash2Op, Seed, TotalLengthInBytes, Source);
+    return(Result);
+}
+
+//
+// NOTE(casey): 512-wide VAES Meow (maximum of 64 bytes/clock single threaded)
+//
+
+static meow_macroblock_result
+MeowHash4Op(int BlockCount, meow_u8 *Source)
+{
+    meow_u512 S0123 = _mm512_setzero_si512();
+    meow_u512 S4567 = _mm512_setzero_si512();
+    meow_u512 S89AB = _mm512_setzero_si512();
+    meow_u512 SCDEF = _mm512_setzero_si512();
+    
+    while(BlockCount--)
+    {
+        S0123 = _mm512_aesdec_epi128(S0123, *(meow_u512 *)(From));
+        S4567 = _mm512_aesdec_epi128(S4567, *(meow_u512 *)(From + 64));
+        S89AB = _mm512_aesdec_epi128(S89AB, *(meow_u512 *)(From + 128));
+        SCDEF = _mm512_aesdec_epi128(SCDEF, *(meow_u512 *)(From + 192));
+        
+        Source += (1 << MEOW_HASH_BLOCK_SIZE_SHIFT);
+    }
+    
+    meow_macroblock_result Result;
+    _mm512_store_si512((meow_u512 *)&Result.S0, S0123);
+    _mm512_store_si512((meow_u512 *)&Result.S4, S4567);
+    _mm512_store_si512((meow_u512 *)&Result.S8, S89AB);
+    _mm512_store_si512((meow_u512 *)&Result.SC, SCDEF);
+    
+    return(Result);
+}
+
+static meow_hash
+MeowHash4(meow_u64 Seed, meow_u64 TotalLengthInBytes, void *Source)
+{
+    // TODO(casey): Once we can test, do the optimized non-megabyte version for 512-bit
+    meow_hash Result = MeowHashViaOp(MeowHash4Op, Seed, TotalLengthInBytes, Source);
+    return(Result);
+}
 
 #endif

--- a/utils/meow_bench.cpp
+++ b/utils/meow_bench.cpp
@@ -4,109 +4,381 @@
    (C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)
    
    See https://mollyrocket.com/meowhash for details.
-   See accompanying meow.inl for license and usage.
    
    ======================================================================== */
 
-#include <intrin.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
-// TODO(casey): At some point, it would be nice to port this to non-Windows /
-// CLANG x64, which supports rdtsc as well, but I need to include some "define
-// cracking" here to test which one we're on and get the right intrinsics and
-// include the right stuff.
+#include "meow_test.h"
+
+//
+// NOTE(casey): Minimalist code for testing threading.
+// DO NOT use this kind of code for running Meow hash in your actual
+// application!  It should be integrated properly into whatever thread pool /
+// job system you are using!
+//
+// {
+//
+
+#if _WIN32
 #include <windows.h>
 
-#define MEOW_HASH_256
-#define MEOW_HASH_512
-#include "meow_hash.h"
+static meow_macroblock_op * volatile WorkOp;
+static meow_macroblock_result WorkResults[1024];
+static meow_source_blocks Work;
 
-struct named_specialization
+static volatile long WorkNumber;
+static volatile long CompletionNumber;
+static volatile long CompletionNumberTarget;
+
+static void
+DoThreadWork(void)
 {
-    char *Name;
-    meow_hash_implementation *Handler;
+    if(WorkNumber < CompletionNumberTarget)
+    {
+        int WorkUnit = _InterlockedExchangeAdd(&WorkNumber, 1);
+        if(WorkUnit < CompletionNumberTarget)
+        {
+            meow_macroblock Macroblock = MeowGetMacroblock(&Work, WorkUnit);
+            WorkResults[WorkUnit] = WorkOp(Macroblock.BlockCount, Macroblock.Source);
+            _InterlockedExchangeAdd(&CompletionNumber, 1);
+        }
+    }
+}
+
+static DWORD WINAPI
+ThreadEntry(LPVOID Parameter)
+{
+    for(;;)
+    {
+        DoThreadWork();
+    }
+}
+#endif
+
+//
+// }
+//
+
+struct best_result
+{
+    meow_u64 Size;
+    meow_u64 Clocks;
 };
 
-static named_specialization Specializations[] =
-{
-#if defined(MEOW_HASH_512)
-    {"MeowHash AVX-512 VAES", MeowHash4},
-#endif
-#if defined(MEOW_HASH_256)
-    {"MeowHash AVX-256 VAES", MeowHash2},
-#endif
-    {"MeowHash SSE AES-NI  ", MeowHash1},
-};
-
-void
+int
 main(int ArgCount, char **Args)
 {
-    printf("\n");
-    printf("meow_bench %s - basic RDTSC-based benchmark for the Meow hash\n", MEOW_HASH_VERSION_NAME);
-    printf("    See https://mollyrocket.com/meowhash for details\n");
-    printf("    WARNING: Counts are NOT accurate if CPU power throttling is enabled\n");
-    printf("\n");
-    printf("Versions compiled into this benchmark:\n");
-    for(int SpecializationIndex = 0;
-        SpecializationIndex < (sizeof(Specializations)/sizeof(Specializations[0]));
-        ++SpecializationIndex)
+    //
+    // NOTE(casey): Print the banner and status
+    //
+    
+    fprintf(stderr, "\n");
+    fprintf(stderr, "meow_bench %s - basic RDTSC-based benchmark for the Meow hash\n", MEOW_HASH_VERSION_NAME);
+    fprintf(stderr, "    See https://mollyrocket.com/meowhash for details\n");
+    fprintf(stderr, "    WARNING: Counts are NOT accurate if CPU power throttling is enabled\n");
+    fprintf(stderr, "             (You must turn it off in your OS if you haven't yet!)\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Versions compiled into this benchmark:\n");
+    for(int TypeIndex = 0;
+        TypeIndex < ArrayCount(NamedHashTypes);
+        ++TypeIndex)
     {
-        named_specialization Specialization = Specializations[SpecializationIndex];
-        printf("    %d. %s\n", SpecializationIndex + 1, Specialization.Name);
+        named_hash_type Type = NamedHashTypes[TypeIndex];
+        fprintf(stderr, "    %d. %s\n", TypeIndex + 1, Type.FullName);
     }
     
-    printf("\n");
-    printf("Test results:\n");
-    int Size = 32*1024;
-    int TestCount = 8000000;
-    for(int Batch = 0;
-        Batch < 16;
-        ++Batch)
+    fprintf(stderr, "\n");
+    
+    //
+    // NOTE(casey): Check if we're testing everybody, or just Meow
+    //
+    int AllowOthers = !(((ArgCount == 2) && (strcmp(Args[1], "meow") == 0)));
+    
+    //
+    // NOTE(casey): Test single-thread performance for each implementation on increasingly large input sizes
+    //
+    
+    meow_u64 MaxClocksWithoutDrop = 4000000000ULL;
+    best_result Bests[40] = {};
+    double BytesPerCycle[ArrayCount(NamedHashTypes)][ArrayCount(Bests)] = {};
+    
     {
-        void *Buffer = _aligned_malloc(Size, 128);
-        
-        for(int SpecializationIndex = 0;
-            SpecializationIndex < (sizeof(Specializations)/sizeof(Specializations[0]));
-            ++SpecializationIndex)
+        int BestIndex = 0;
+        Bests[BestIndex++].Size = 1;
+        Bests[BestIndex++].Size = 7;
+        Bests[BestIndex++].Size = 8;
+        Bests[BestIndex++].Size = 15;
+        Bests[BestIndex++].Size = 16;
+        Bests[BestIndex++].Size = 31;
+        Bests[BestIndex++].Size = 32;
+        Bests[BestIndex++].Size = 63;
+        Bests[BestIndex++].Size = 64;
+        Bests[BestIndex++].Size = 127;
+        Bests[BestIndex++].Size = 128;
+        Bests[BestIndex++].Size = 255;
+        Bests[BestIndex++].Size = 256;
+        Bests[BestIndex++].Size = 511;
+        Bests[BestIndex++].Size = 512;
+        Bests[BestIndex++].Size = 1023;
+        Bests[BestIndex++].Size = 1024;
+        meow_u64 Size = Bests[BestIndex - 1].Size;
+        while(BestIndex < ArrayCount(Bests))
         {
-            named_specialization Specialization = Specializations[SpecializationIndex];
-            __try
+            Size *= 2;
+            Bests[BestIndex++].Size = Size;
+        }
+    }
+    
+    {
+        fprintf(stderr, "Single-threaded performance:\n");
+        for(int Batch = 0;
+            Batch < ArrayCount(Bests);
+            ++Batch)
+        {
+            best_result *ThisBest = Bests + Batch;
+            meow_u64 Size = ThisBest->Size;
+            ThisBest->Clocks = (meow_u64)-1ULL;
+            
+            void *Buffer = aligned_alloc(MEOW_HASH_ALIGNMENT, Size);
+            if(Buffer)
             {
-                meow_u64 BestClocks = (meow_u64)-1;
-                for(int Test = 0;
-                    Test < TestCount;
-                    ++Test)
+                fprintf(stderr, "  Fewest cycles to hash ");
+                PrintSize(stderr, Size, false);
+                fprintf(stderr, ":\n");
+                
+                for(int TypeIndex = 0;
+                    TypeIndex < ArrayCount(NamedHashTypes);
+                    ++TypeIndex)
                 {
-                    meow_u64 StartClock = __rdtsc();
-                    Specialization.Handler(0, Size, Buffer);
-                    meow_u64 EndClock = __rdtsc();
-                    
-                    meow_u64 Clocks = EndClock - StartClock;
-                    if(BestClocks > Clocks)
+                    named_hash_type Type = NamedHashTypes[TypeIndex];
+                    if(AllowOthers || Type.Op)
                     {
-                        printf("\r%s least cycles to hash %uk: %u (%f bytes/cycle)               ",
-                               Specialization.Name,
-                               (Size/1024), (int unsigned)BestClocks, (double)Size / (double)BestClocks);
-                        Test = 0;
-                        BestClocks = Clocks;
+                        TRY
+                        {
+                            meow_u64 ClocksSinceLastDrop = 0;
+                            meow_u64 BestClocks = (meow_u64)-1ULL;
+                            int TryIndex = 0;
+                            while((TryIndex < 10) || (ClocksSinceLastDrop < MaxClocksWithoutDrop))
+                            {
+                                meow_u64 StartClock = __rdtsc();
+                                Type.Imp(0, Size, Buffer);
+                                meow_u64 EndClock = __rdtsc();
+                                
+                                meow_u64 Clocks = EndClock - StartClock;
+                                ClocksSinceLastDrop += Clocks;
+                                
+                                if(BestClocks > Clocks)
+                                {
+                                    ClocksSinceLastDrop = 0;
+                                    BestClocks = Clocks;
+                                }
+                                
+                                ++TryIndex;
+                            }
+                            
+                            double BPC = (double)Size / (double)BestClocks;
+                            fprintf(stderr, "    %32s %10.0f (%3.03f bytes/cycle)\n",
+                                    Type.FullName, (double)BestClocks, BPC);
+                            fflush(stderr);
+                            
+                            BytesPerCycle[TypeIndex][Batch] = BPC;
+                            
+                            if(ThisBest->Clocks > BestClocks)
+                            {
+                                ThisBest->Clocks = BestClocks;
+                            }
+                        }
+                        CATCH
+                        {
+                            if(Batch == 0)
+                            {
+                                fprintf(stderr, "(%s not supported on this CPU)\n",
+                                        Type.FullName);
+                                Type.Op = 0;
+                            }
+                        }
                     }
                 }
-                printf("\n");
-            }
-            __except(1)
-            {
-                if(Batch == 0)
-                {
-                    printf("(%s not supported on this CPU)\n",
-                           Specialization.Name);
-                }
+                
+                free(Buffer);
             }
         }
-        
-        _aligned_free(Buffer);
-        
-        Size *= 2;
-        TestCount /= 2;
     }
+    
+    fprintf(stderr, "\n");
+    
+    //
+    // NOTE(casey): Print the single-thread leaderboard (whichever hash was fastest)
+    //
+    
+    fprintf(stderr, "Leaderboard:\n");
+    for(int BestIndex = 0;
+        BestIndex < ArrayCount(Bests);
+        ++BestIndex)
+    {
+        best_result *Best = Bests + BestIndex;
+        fprintf(stderr, "  ");
+        PrintSize(stderr, Best->Size, true);
+        double BPC = (double)Best->Size / (double)Best->Clocks;
+        fprintf(stderr, ": %10.0f (%3.03f bytes/cycle) - ",
+                (double)Best->Clocks, BPC);
+        
+        int TieCount = 0;
+        for(int TypeIndex = 0;
+            TypeIndex < ArrayCount(NamedHashTypes);
+            ++TypeIndex)
+        {
+            if(BPC == BytesPerCycle[TypeIndex][BestIndex])
+            {
+                named_hash_type Type = NamedHashTypes[TypeIndex];
+                
+                if(TieCount)
+                {
+                    fprintf(stderr, ", ");
+                }
+                
+                fprintf(stderr, "%s", Type.FullName);
+                
+                ++TieCount;
+            }
+        }
+        if(TieCount > 1)
+        {
+            fprintf(stderr, " (%d-way tie)", TieCount);
+        }
+        fprintf(stderr, "\n");
+    }
+    
+    fprintf(stderr, "\n");
+    
+    //
+    // NOTE(casey): Print a CSV-style section for peeps who want to graph
+    //
+
+    fprintf(stdout, "Input");
+    for(int TypeIndex = 0;
+        TypeIndex < ArrayCount(NamedHashTypes);
+        ++TypeIndex)
+    {
+        named_hash_type Type = NamedHashTypes[TypeIndex];
+        fprintf(stdout, ",%s", Type.FullName);
+    }
+    fprintf(stdout, "\n");
+    
+    for(int BestIndex = 0;
+        BestIndex < ArrayCount(Bests);
+        ++BestIndex)
+    {
+        best_result *Best = Bests + BestIndex;
+        PrintSize(stdout, Best->Size, false);
+        
+        for(int TypeIndex = 0;
+            TypeIndex < ArrayCount(NamedHashTypes);
+            ++TypeIndex)
+        {
+            fprintf(stdout, ",%f", BytesPerCycle[TypeIndex][BestIndex]);
+        }
+        fprintf(stdout, "\n");
+    }
+    fprintf(stdout, "\n");
+    fflush(stdout);
+    
+#if _WIN32
+    //
+    // NOTE(casey): Test multiple-thread performance for each Meow implementation
+    //
+    
+    {
+        SYSTEM_INFO SystemInfo = {};
+        GetSystemInfo(&SystemInfo);
+        int MaxThreadCount = SystemInfo.dwNumberOfProcessors + 2;
+        
+        int Size = 1024*1024*1024;
+        fprintf(stderr, "Multi-threaded performance (Meow only):\n");
+        for(int ThreadCount = 1;
+            ThreadCount < MaxThreadCount;
+            ++ThreadCount)
+        {
+            void *Buffer = aligned_alloc(MEOW_HASH_ALIGNMENT, Size);
+            meow_hash ReferenceHash = MeowHash1(0, Size, Buffer);
+            Work = MeowSourceBlocksFor(Size, Buffer);
+            
+            for(int TypeIndex = 0;
+                TypeIndex < ArrayCount(NamedHashTypes);
+                ++TypeIndex)
+            {
+                named_hash_type Type = NamedHashTypes[TypeIndex];
+                if(Type.Op)
+                {
+                    WorkOp = Type.Op;
+                    meow_u64 BestClocks = (meow_u64)-1ULL;
+                    for(int Test = 0;
+                        Test < 100;
+                        ++Test)
+                    {
+                        InterlockedAnd(&CompletionNumberTarget, 0);
+                        _ReadWriteBarrier(); _mm_mfence();
+                        CompletionNumber = 0;
+                        WorkNumber = 0;
+                        _ReadWriteBarrier(); _mm_mfence();
+                        
+                        meow_u64 StartClock = __rdtsc();
+                        CompletionNumberTarget = Work.MacroblockCount;
+                        while(CompletionNumber < CompletionNumberTarget)
+                        {
+                            DoThreadWork();
+                        }
+                        
+                        _ReadWriteBarrier();
+                        
+                        // TODO(casey): Technically I would like to force a re-read of WorkResults here.
+                        // I don't really know how to convince the compiler to do that.  Currently it does,
+                        // but it'd be nice to guard against a day when it learns to optimize it out.  I
+                        // want something like "this is a barrier where you have to treat it as volatile
+                        // between before and after the barrier", which I don't think exists?  Like a
+                        // "consider_this_pointers_memory_changed_as_of_right_now()" intrinsic.
+                        
+                        meow_macroblock_result Group = MeowHashMergeArray(Work.MacroblockCount, WorkResults);
+                        meow_hash Hash = MeowHashFinish(&Group, 0, Work.TotalLengthInBytes, Work.Overhang, Work.OverhangStart);
+                        
+                        _ReadWriteBarrier();
+                        
+                        meow_u64 EndClock = __rdtsc();
+                        
+                        if(!MeowHashesAreEqual(Hash, ReferenceHash))
+                        {
+                            fprintf(stderr, "ERROR: Multithreaded hash failed to produce the same hash as the single-threaded hash!\n");
+                            ExitProcess(0);
+                        }
+                        
+                        meow_u64 Clocks = EndClock - StartClock;
+                        if(BestClocks > Clocks)
+                        {
+                            BestClocks = Clocks;
+                            fprintf(stderr, "\r%s fastest hash of ", Type.FullName);
+                            PrintSize(stderr, Size, false);
+                            fprintf(stderr, " on %u thread%s: %0.0f (%f bytes/cycle)               ",
+                                    ThreadCount, (ThreadCount == 1) ? " " : "s", (double)BestClocks, (double)Size / (double)BestClocks);
+                            fflush(stderr);
+                            Test = 0;
+                        }
+                    }
+                    fprintf(stderr, "\n");
+                }
+            }
+            
+            free(Buffer);
+        
+            DWORD ThreadID;
+            CloseHandle(CreateThread(0, 0, ThreadEntry, 0, 0, &ThreadID));
+        }
+    }
+    
+    ExitProcess(0);
+#endif
+    
+    return(0);
 }

--- a/utils/meow_search.cpp
+++ b/utils/meow_search.cpp
@@ -1,0 +1,480 @@
+/* ========================================================================
+
+   meow_search.cpp - basic file system Meow hash collision search
+   (C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)
+   
+   See https://mollyrocket.com/meowhash for details.
+   
+   ======================================================================== */
+
+#include <stdio.h>
+#include <string.h>
+#include <memory.h>
+#include <time.h>
+#if _WIN32
+#include <windows.h>
+#else
+#include <dirent.h>
+#endif
+
+#undef MEOW_HASH_AVX512
+#define MEOW_HASH_AVX512 0
+#define MEOW_INCLUDE_TRUNCATIONS 1
+#include "meow_test.h"
+
+struct test_file
+{
+    test_file *Next;
+    char *FileName;
+    int IsCollision;
+};
+
+struct test_value
+{
+    meow_hash Hash;
+    test_value *Next;
+    test_file *FirstFile;
+};
+
+struct test
+{
+    named_hash_type Type;
+    meow_u64 CollisionCount;
+    test_value *Table[4096];
+};
+
+struct test_group
+{
+    int TestCount;
+    test *Tests;
+
+    // NOTE(casey): Statistics
+    meow_u64 FileCount;
+    meow_u64 ByteCount;
+    meow_u64 DuplicateFileCount;
+    
+    // NOTE(casey): Errors
+    meow_u64 AccessFailureCount;
+    meow_u64 AllocationFailureCount;
+    meow_u64 ReadFailureCount;
+    
+    char *ReportFileName;
+    char *RootPath;
+};
+
+struct entire_file
+{
+    size_t Size;
+    void *Contents;
+};
+
+static void
+FreeEntireFile(entire_file *File)
+{
+    if(File->Contents)
+    {
+        free(File->Contents);
+        File->Contents = 0;
+    }
+    
+    File->Size = 0;
+}
+
+static entire_file
+ReadEntireFile(test_group *Group, char *Filename)
+{
+    entire_file Result = {};
+    
+    FILE *File = fopen(Filename, "rb");
+    if(File)
+    {
+        fseek(File, 0, SEEK_END);
+        Result.Size = ftell(File);
+        fseek(File, 0, SEEK_SET);
+        
+        Result.Contents = aligned_alloc(MEOW_HASH_ALIGNMENT, Result.Size);
+        if(Result.Contents)
+        {
+            if(Result.Size)
+            {
+                if(fread(Result.Contents, Result.Size, 1, File) == 1)
+                {
+                    // NOTE(casey): Success!
+                }
+                else
+                {
+                    FreeEntireFile(&Result);
+                    ++Group->ReadFailureCount;
+                }
+            }
+        }
+        else
+        {
+            Result.Size = 0;
+            ++Group->AllocationFailureCount;
+        }
+        
+        fclose(File);
+    }
+    else
+    {
+        ++Group->AccessFailureCount;
+    }
+   
+    
+    return(Result);
+}
+
+static void
+WriteReport(test_group *Group, int Completed)
+{
+    FILE *R = fopen(Group->ReportFileName, "w");
+    if(R)
+    {
+        time_t Time;
+        time(&Time);
+        tm *TimeInfo = localtime(&Time);
+        
+        fprintf(R, "meow_search %s results:\n", MEOW_HASH_VERSION_NAME);
+        fprintf(R, "    Root: %s\n", Group->RootPath);
+        fprintf(R, "    %s: %s", Completed ? "Completed on" : "Progress as of", asctime(TimeInfo));
+        fprintf(R, "    Files: %0.0f\n", (double)Group->FileCount);
+        fprintf(R, "    Total size: ");
+        PrintSize(R, Group->ByteCount, false);
+        fprintf(R, "\n");
+        fprintf(R, "    Duplicate files: %0.0f\n", (double)Group->DuplicateFileCount);
+        fprintf(R, "    Access failures: %0.0f\n", (double)Group->AccessFailureCount);
+        fprintf(R, "    Allocation failures: %0.0f\n", (double)Group->AllocationFailureCount);
+        fprintf(R, "    Read failures: %0.0f\n", (double)Group->ReadFailureCount);
+        
+        for(int TestIndex = 0;
+            TestIndex < Group->TestCount;
+            ++TestIndex)
+        {
+            test *Test = Group->Tests + TestIndex;
+            fprintf(R, "    [%s] %s collisions: %0.0f\n", Test->Type.ShortName, Test->Type.FullName, (double)Test->CollisionCount);
+            for(int HashSlot = 0;
+                HashSlot < ArrayCount(Test->Table);
+                ++HashSlot)
+            {
+                for(test_value *Value = Test->Table[HashSlot];
+                    Value;
+                    Value = Value->Next)
+                {
+                    int IsCollision = 0;
+                    for(test_file *File = Value->FirstFile;
+                        File;
+                        File = File->Next)
+                    {
+                        if(File->IsCollision)
+                        {
+                            IsCollision = 1;
+                            break;
+                        }
+                    }
+                    
+                    if(IsCollision)
+                    {
+                        fprintf(R, "        ");
+                        PrintHash(R, Value->Hash);
+                        fprintf(R, ":\n");
+                        
+                        for(test_file *File = Value->FirstFile;
+                            File;
+                            File = File->Next)
+                        {
+                            if(File->IsCollision)
+                            {
+                                fprintf(R, "            %s\n", File->FileName);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        fclose(R);
+    }
+}
+
+static void
+IngestFile(test_group *Group, char *FileName)
+{
+    entire_file File = ReadEntireFile(Group, FileName);
+    if(File.Contents)
+    {
+        ++Group->FileCount;
+        Group->ByteCount += File.Size;
+        
+        int QuickStatus = ((Group->FileCount % 10) == 0);
+        if(QuickStatus)
+        {
+            double Gigabyte = 1024.0*1024.0*1024.0;
+            printf("\r%0.0f files, %0.02fgb, %0.0f dupes",
+                   (double)Group->FileCount,
+                   (double)Group->ByteCount / (double)Gigabyte,
+                   (double)Group->DuplicateFileCount);
+        }
+        
+        if((Group->FileCount % 1000) == 0)
+        {
+            WriteReport(Group, false);
+        }
+        
+        int DuplicateFileFound = 0;
+        for(int TestIndex = 0;
+            TestIndex < Group->TestCount;
+            ++TestIndex)
+        {
+            test *Test = Group->Tests + TestIndex;
+            
+            meow_hash Hash = Test->Type.Imp(0, File.Size, File.Contents);
+            
+            test_value **Slot = &Test->Table[Hash.u32[0] % ArrayCount(Test->Table)];
+            test_value *Entry = *Slot;
+            while(Entry && memcmp(&Entry->Hash, &Hash, sizeof(Hash)))
+            {
+                Entry = Entry->Next;
+            }
+            
+            int IsCollision = 0;
+            if(Entry)
+            {
+                for(test_file *Check = Entry->FirstFile;
+                    Check;
+                    Check = Check->Next)
+                {
+                    entire_file OtherFile = ReadEntireFile(Group, Check->FileName);
+                    if(OtherFile.Contents &&
+                       ((File.Size != OtherFile.Size) ||
+                        memcmp(File.Contents, OtherFile.Contents, File.Size)))
+                    {
+                        Check->IsCollision = 1;
+                        IsCollision = 1;
+                        ++Test->CollisionCount;
+                    }
+                    else
+                    {
+                        DuplicateFileFound = 1;
+                    }
+                    FreeEntireFile(&OtherFile);
+                }
+            }
+            else
+            {
+                Entry = (test_value *)malloc(sizeof(test_value));
+                Entry->Hash = Hash;
+                Entry->FirstFile = 0;
+                Entry->Next = *Slot;
+                *Slot = Entry;
+            }
+            
+            test_file *TestFile = (test_file *)malloc(sizeof(test_file));
+            TestFile->FileName = FileName;
+            TestFile->Next = Entry->FirstFile;
+            TestFile->IsCollision = IsCollision;
+            Entry->FirstFile = TestFile;
+            
+            if(QuickStatus && Test->CollisionCount)
+            {
+                printf(" %s:%u!", Test->Type.ShortName, (int unsigned)Test->CollisionCount);
+            }
+        }
+        
+        if(QuickStatus)
+        {
+            fflush(stdout);
+        }
+        
+        Group->DuplicateFileCount += DuplicateFileFound;
+    }
+    
+    FreeEntireFile(&File);
+}
+
+static void IngestDirectoriesRecursively(test_group *Group, char *Path);
+int main(int ArgCount, char **Args)
+{
+    int Result = -1;
+    
+    if(ArgCount == 3)
+    {
+        // NOTE(casey): Strip trailing slashes from the input
+        char *RootPath = Args[1];
+        size_t RootPathLen = strlen(Args[1]);
+        while(RootPathLen)
+        {
+            --RootPathLen;
+            if((RootPath[RootPathLen] == '/') ||
+               (RootPath[RootPathLen] == '\\'))
+            {
+                RootPath[RootPathLen] = 0;
+            }
+            else
+            {
+                break;
+            }
+        }
+        
+        char *ReportFileName = Args[2];
+        FILE *ReportFileTest = fopen(ReportFileName, "rb");
+        if(!ReportFileTest)
+        {
+            // NOTE(casey): Prepare the test group
+            test Tests[ArrayCount(NamedHashTypes)] = {};
+            for(int TestIndex = 0;
+                TestIndex < ArrayCount(Tests);
+                ++TestIndex)
+            {
+                Tests[TestIndex].Type = NamedHashTypes[TestIndex];
+            }
+            
+            test_group Group = {};
+            Group.TestCount = ArrayCount(Tests);
+            Group.Tests = Tests;
+            Group.ReportFileName = ReportFileName;
+            Group.RootPath = RootPath;
+            
+            // NOTE(casey): Print the banner
+            time_t Time;
+            time(&Time);
+            tm *TimeInfo = localtime(&Time);
+            
+            printf("meow_search %s began at %s", MEOW_HASH_VERSION_NAME, asctime(TimeInfo));
+            printf("Root: %s\n", RootPath);
+            printf("Hash types:\n");
+            for(int TestIndex = 0;
+                TestIndex < Group.TestCount;
+                ++TestIndex)
+            {
+                test *Test = Group.Tests + TestIndex;
+                printf("    %s = %s\n", Test->Type.ShortName, Test->Type.FullName);
+            }
+            
+            // NOTE(casey): Run the search
+            IngestDirectoriesRecursively(&Group, RootPath);
+            printf("\n");
+            printf("meow_search complete.\n");
+            
+            // NOTE(casey): Report the results
+            WriteReport(&Group, true);
+            
+            // NOTE(casey): Prepare a result code based on the collision count
+            Result = (int)Group.Tests[MEOW_HASH_TEST_INDEX_128].CollisionCount;
+        }
+        else
+        {
+            printf("ERROR: %s already exists.  Please specify a different report filename.\n", ReportFileName);
+            fclose(ReportFileTest);
+        }
+    }
+    else
+    {
+        printf("Usage: %s <directory to search recursively> <report filename to write>\n", Args[0]);
+    }
+    
+    return(Result);
+}
+
+//
+// NOTE(casey) Platform-specific directory walking
+//
+
+static char *
+AllocPath(char *A, char *B)
+{
+    size_t ACount = strlen(A);
+    size_t BCount = strlen(B);
+    size_t Size = ACount + BCount + 2;
+    
+    char *Result = (char *)malloc(Size);
+    memcpy(Result, A, ACount);
+    memcpy(Result + ACount + 1, B, BCount);
+    Result[ACount] = '/';
+    Result[Size - 1] = 0;
+    
+    return(Result);
+}
+
+static void
+DeallocPath(char *A)
+{
+    if(A)
+    {
+        free(A);
+    }
+}
+
+#if _WIN32
+
+static void
+IngestDirectoriesRecursively(test_group *Group, char *Path)
+{
+    char *Wildcard = AllocPath(Path, "*");
+    
+    WIN32_FIND_DATAA FindData;
+    HANDLE SearchHandle = FindFirstFileExA(Wildcard, FindExInfoBasic, &FindData,
+                                           FindExSearchNameMatch, 0, FIND_FIRST_EX_LARGE_FETCH);
+    if(SearchHandle != INVALID_HANDLE_VALUE)
+    {
+        do
+        {
+            char *Stem = FindData.cFileName;
+            if(strcmp(Stem, ".") && strcmp(Stem, ".."))
+            {
+                char *EntryName = AllocPath(Path, Stem);
+                if(FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+                {
+                    IngestDirectoriesRecursively(Group, EntryName);
+                }
+                else
+                {
+                    IngestFile(Group, EntryName);
+                }
+            }
+        } while(FindNextFileA(SearchHandle, &FindData));
+        
+        FindClose(SearchHandle);
+    }
+    
+    DeallocPath(Wildcard);
+}
+
+#else
+
+static void
+IngestDirectoriesRecursively(test_group *Group, char *Path)
+{
+    DIR *DirHandle = opendir(Path);
+    if(DirHandle)
+    {
+        for(dirent *Entry = readdir(DirHandle);
+            Entry;
+            Entry = readdir(DirHandle))
+        {
+            // NOTE(casey): We intentionally never free these, because they are
+            // used in the permanent structure.
+            char *Stem = Entry->d_name;
+            char *EntryName = AllocPath(Path, Stem);
+            if(strcmp(Stem, ".") && strcmp(Stem, ".."))
+            {
+                if(Entry->d_type == DT_UNKNOWN)
+                {
+                    ++Group->AccessFailureCount;
+                }
+                else if(Entry->d_type == DT_DIR)
+                {
+                    IngestDirectoriesRecursively(Group, EntryName);
+                }
+                else if(Entry->d_type == DT_REG)
+                {
+                    IngestFile(Group, EntryName);
+                }
+            }
+        }
+        
+        closedir(DirHandle);
+    }
+}
+
+#endif

--- a/utils/meow_smhasher.cpp
+++ b/utils/meow_smhasher.cpp
@@ -7,7 +7,11 @@
    
    ======================================================================== */
 
+#if _MSC_VER
 #include <intrin.h>
+#else
+#include <x86intrin.h>
+#endif
 
 #include "meow_hash.h"
 
@@ -18,107 +22,77 @@
 void
 Meow1_32(const void * key, int len, meow_u32 seed, void * out)
 {
-    meow_lane Result = MeowHash1(seed, len, (void *)key);
-    *(meow_u32 *)out = (meow_u32)Result.Sub[0];
+    meow_hash Result = MeowHash1(seed, len, (void *)key);
+    *(meow_u32 *)out = Result.u32[0];
 }
 
 void
 Meow1_64(const void * key, int len, meow_u32 seed, void * out)
 {
-    meow_lane Result = MeowHash1(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
+    meow_hash Result = MeowHash1(seed, len, (void *)key);
+    ((meow_u64 *)out)[0] = Result.u64[0];
 }
 
 void
 Meow1_128(const void * key, int len, meow_u32 seed, void * out)
 {
-    meow_lane Result = MeowHash1(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
+    meow_hash Result = MeowHash1(seed, len, (void *)key);
+    ((meow_u64 *)out)[0] = Result.u64[0];
+    ((meow_u64 *)out)[1] = Result.u64[1];
 }
 
-void
-Meow1_256(const void * key, int len, meow_u32 seed, void * out)
-{
-    meow_lane Result = MeowHash1(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
-    ((meow_u64 *)out)[2] = Result.Sub[2];
-    ((meow_u64 *)out)[3] = Result.Sub[3];
-}
+#if MEOW_HASH_AVX512
 
 //
 // NOTE(casey): 256-bit wide implementation (Meow2)
 //
 
-#if defined(MEOW_HASH_256)
 void
 Meow2_32(const void * key, int len, meow_u32 seed, void * out)
 {
-    meow_lane Result = MeowHash2(seed, len, (void *)key);
-    *(meow_u32 *)out = (meow_u32)Result.Sub[0];
+    meow_hash Result = MeowHash2(seed, len, (void *)key);
+    *(meow_u32 *)out = Result.u32[0];
 }
 
 void
 Meow2_64(const void * key, int len, meow_u32 seed, void * out)
 {
-    meow_lane Result = MeowHash2(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
+    meow_hash Result = MeowHash2(seed, len, (void *)key);
+    ((meow_u64 *)out)[0] = Result.u64[0];
 }
 
 void
 Meow2_128(const void * key, int len, meow_u32 seed, void * out)
 {
-    meow_lane Result = MeowHash2(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
+    meow_hash Result = MeowHash2(seed, len, (void *)key);
+    ((meow_u64 *)out)[0] = Result.u64[0];
+    ((meow_u64 *)out)[1] = Result.u64[1];
 }
-
-void
-Meow2_256(const void * key, int len, meow_u32 seed, void * out)
-{
-    meow_lane Result = MeowHash2(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
-    ((meow_u64 *)out)[2] = Result.Sub[2];
-    ((meow_u64 *)out)[3] = Result.Sub[3];
-}
-#endif
 
 //
 // NOTE(casey): 512-bit wide implementation (Meow4)
 //
 
-#if defined(MEOW_HASH_512)
 void
 Meow4_32(const void * key, int len, meow_u32 seed, void * out)
 {
-    meow_lane Result = MeowHash4(seed, len, (void *)key);
-    *(meow_u32 *)out = (meow_u32)Result.Sub[0];
+    meow_hash Result = MeowHash4(seed, len, (void *)key);
+    *(meow_u32 *)out = Result.u32[0];
 }
 
 void
 Meow4_64(const void * key, int len, meow_u32 seed, void * out)
 {
-    meow_lane Result = MeowHash4(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
+    meow_hash Result = MeowHash4(seed, len, (void *)key);
+    ((meow_u64 *)out)[0] = Result.u64[0];
 }
 
 void
 Meow4_128(const void * key, int len, meow_u32 seed, void * out)
 {
-    meow_lane Result = MeowHash4(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
+    meow_hash Result = MeowHash4(seed, len, (void *)key);
+    ((meow_u64 *)out)[0] = Result.u64[0];
+    ((meow_u64 *)out)[1] = Result.u64[1];
 }
 
-void
-Meow4_256(const void * key, int len, meow_u32 seed, void * out)
-{
-    meow_lane Result = MeowHash4(seed, len, (void *)key);
-    ((meow_u64 *)out)[0] = Result.Sub[0];
-    ((meow_u64 *)out)[1] = Result.Sub[1];
-    ((meow_u64 *)out)[2] = Result.Sub[2];
-    ((meow_u64 *)out)[3] = Result.Sub[3];
-}
 #endif

--- a/utils/meow_test.cpp
+++ b/utils/meow_test.cpp
@@ -1,0 +1,160 @@
+/* ========================================================================
+
+   meow_test.cpp - basic sanity checking for any build of Meow hash
+   (C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)
+   
+   See https://mollyrocket.com/meowhash for details.
+   
+   ======================================================================== */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <memory.h>
+
+#include "meow_test.h"
+
+//
+// NOTE(casey): Minimalist code for Meow testing.
+//
+// This is NOT a replacement for the real hash testing (done via smhasher, etc.)
+// It is just a brief sanity check to ensure that your Meow compilation is
+// working correctly.
+//
+
+int
+main(int ArgCount, char **Args)
+{
+    int Result = 0;
+    
+    // NOTE(casey): Print the banner
+    printf("meow_test %s - basic sanity test for a Meow hash build\n", MEOW_HASH_VERSION_NAME);
+    printf("    See https://mollyrocket.com/meowhash for details\n");
+    printf("\n");
+    
+    printf("Unaligned sources: ");
+    {
+        meow_u8 *Test = (meow_u8 *)aligned_alloc(MEOW_HASH_ALIGNMENT, 257);
+        TRY
+        {
+            MeowHash1(0, 256, Test + 1);
+            printf("supported");
+        }
+        CATCH
+        {
+            printf("UNSUPPORTED");
+        }
+        free(Test);
+    }
+    printf("\n");
+    
+    for(int TypeIndex = 0;
+        TypeIndex < ArrayCount(NamedHashTypes);
+        ++TypeIndex)
+    {
+        named_hash_type *Type = NamedHashTypes + TypeIndex;
+        if(Type->Op)
+        {
+            int TotalPossible = 0;
+            int ImpError = 0;
+            int OpError = 0;
+            int Unsupported = 0;
+            
+            printf("%s: ", Type->FullName);
+            
+            for(int BufferSize = 1;
+                BufferSize <= 2048;
+                ++BufferSize)
+            {
+                int AllocationSize = BufferSize + 2*MEOW_HASH_ALIGNMENT;
+                meow_u8 *Allocation = (meow_u8 *)aligned_alloc(MEOW_HASH_ALIGNMENT, AllocationSize);
+                memset(Allocation, 0, AllocationSize);
+                
+                meow_u8 *Buffer = Allocation + MEOW_HASH_ALIGNMENT;
+                for(int Guard = 0;
+                    Guard < 1;
+                    ++Guard)
+                {
+                    for(int Flip = 0;
+                        Flip < BufferSize;
+                        ++Flip)
+                    {
+                        meow_u64 Seed = 0;
+                        
+                        meow_u8 *FlipByte = Buffer + (Flip / 8);
+                        meow_u8 FlipBit = (1 << (Flip % 8));
+                        *FlipByte |= FlipBit;
+                        
+                        meow_hash Canonical = MeowHash1(Seed, BufferSize, Buffer);
+                        if(Guard)
+                        {
+                            memset(Allocation, 0xFF, MEOW_HASH_ALIGNMENT);
+                            memset(Allocation + MEOW_HASH_ALIGNMENT + BufferSize, 0xFF, MEOW_HASH_ALIGNMENT);
+                        }
+                        
+                        ++TotalPossible;
+                        TRY
+                        {
+                            meow_hash ImpHash = Type->Imp(Seed, BufferSize, Buffer);
+                            meow_hash OpHash = MeowHashViaOp(Type->Op, Seed, BufferSize, Buffer);
+                            
+                            if(!MeowHashesAreEqual(Canonical, ImpHash))
+                            {
+                                ++ImpError;
+                            }
+                            
+                            if(!MeowHashesAreEqual(Canonical, OpHash))
+                            {
+                                ++OpError;
+                            }
+                        }
+                        CATCH
+                        {
+                            ++Unsupported;
+                            break;
+                        }
+                        
+                        if(Guard)
+                        {
+                            memset(Allocation, 0, MEOW_HASH_ALIGNMENT);
+                            memset(Allocation + MEOW_HASH_ALIGNMENT + BufferSize, 0, MEOW_HASH_ALIGNMENT);
+                        }
+                        
+                        *FlipByte &= ~FlipBit;
+                    }
+                }
+                
+                free(Allocation);
+            }
+            
+            if(Unsupported)
+            {
+                printf("UNSUPPORTED");
+            }
+            else
+            {
+                if(ImpError || OpError)
+                {
+                    printf("FAILED");
+                    if(ImpError)
+                    {
+                        printf(" [direct:%u/%u]", ImpError, TotalPossible);
+                    }
+                    
+                    if(OpError)
+                    {
+                        printf(" [op:%u/%u]", OpError, TotalPossible);
+                    }
+                    
+                    Result = -1;
+                }
+                else
+                {
+                    printf("PASSED");
+                }
+            }
+            printf("\n");
+        }
+    }
+    
+    return(Result);
+}

--- a/utils/meow_test.h
+++ b/utils/meow_test.h
@@ -1,0 +1,187 @@
+/* ========================================================================
+
+   meow_test.h - shared functions for Meow testing utilities
+   (C) Copyright 2018 by Molly Rocket, Inc. (https://mollyrocket.com)
+   
+   See https://mollyrocket.com/meowhash for details.
+   
+   ======================================================================== */
+
+#if _MSC_VER
+#include <intrin.h>
+#define TRY __try
+#define CATCH __except(1)
+#define malloc(a) _aligned_malloc(4,a)
+#define aligned_alloc(a,b) _aligned_malloc(b,a)
+#define free _aligned_free
+#else
+#include <x86intrin.h>
+#define TRY try
+#define CATCH catch(...)
+#endif
+
+#include "meow_hash.h"
+
+#define ArrayCount(Array) (sizeof(Array)/sizeof((Array)[0]))
+
+static meow_hash
+MeowHashTruncate64(meow_u64 Seed, meow_u64 Len, void *Source)
+{
+    meow_hash Result = MeowHash1(Seed, Len, Source);
+    Result.u64[1] = 0;
+    return(Result);
+}
+
+static meow_hash
+MeowHashTruncate32(meow_u64 Seed, meow_u64 Len, void *Source)
+{
+    meow_hash Result = MeowHashTruncate64(Seed, Len, Source);
+    Result.u32[1] = 0;
+    return(Result);
+}
+
+//
+// NOTE(casey): To avoid having to comply with the notice provisions of
+// lots of different licenses, other hashes for comparison are NOT
+// included in the Meow repository.  However, if you download them
+// yourself, massage them into working together, and put them in an "other"
+// directory, you can enable these bindings to automatically include
+// them in the Meow utilities where applicable.
+//
+
+#if MEOW_INCLUDE_OTHER_HASHES
+
+#if !defined(_MSC_VER) || (_MSC_FULL_VER >= 191025017)
+#define MEOW_T1HA_INCLUDED 1
+#else
+#define MEOW_T1HA_INCLUDED 0
+#endif
+
+#include "other/city.h"
+#include "other/city.cc"
+static meow_hash
+CityHash128(meow_u64 Seed, meow_u64 Len, void *Source)
+{
+    meow_hash Result = {};
+    
+    uint128 Temp = CityHash128((char *)Source, Len);
+    Result.u64[0] = Temp.first;
+    Result.u64[1] = Temp.second;
+    
+    return(Result);
+}
+
+#include "other/falkhash.c"
+static meow_hash
+FalkHash128(meow_u64 Seed, meow_u64 Len, void *Source)
+{
+    meow_hash Result = {};
+    
+    Result.u128 = falkhash(Source, Len, Seed);
+    
+    return(Result);
+}
+
+#include "other/metrohash128.h"
+#include "other/metrohash128.cpp"
+static meow_hash
+MetroHash128(meow_u64 Seed, meow_u64 Len, void *Source)
+{
+    meow_hash Result = {};
+    
+    MetroHash128::Hash((uint8_t *)Source, Len, (uint8_t *)&Result, Seed);
+    
+    return(Result);
+}
+
+#if MEOW_T1HA_INCLUDED
+#include "other/t1ha0_ia32aes_avx.c"
+static meow_hash
+t1ha64(meow_u64 Seed, meow_u64 Len, void *Source)
+{
+    meow_hash Result = {};
+    
+    Result.u64[0] = t1ha0_ia32aes_avx(Source, Len, Seed);
+    
+    return(Result);
+}
+#endif
+
+#include "other/xxhash.c"
+static meow_hash
+xxHash64(meow_u64 Seed, meow_u64 Len, void *Source)
+{
+    meow_hash Result = {};
+    
+    Result.u64[0] = XXH64(Source, Len, Seed);
+    
+    return(Result);
+}
+
+#endif
+
+//
+// NOTE(casey): List of available hash implementations
+//
+
+struct named_hash_type
+{
+    char *ShortName;
+    char *FullName;
+    
+    meow_hash_implementation *Imp;
+    meow_macroblock_op *Op;
+};
+
+static named_hash_type NamedHashTypes[] =
+{
+#define MEOW_HASH_TEST_INDEX_128 0
+    {(char *)"Meow128", (char *)"Meow 128-bit AES-NI 128-wide", MeowHash1, MeowHash1Op},
+#if MEOW_HASH_AVX512
+    {(char *)"Meow128x2", (char *)"Meow 128-bit VAES 256-wide", MeowHash2, MeowHash2Op},
+    {(char *)"Meow128x4", (char *)"Meow 128-bit VAES 512-wide", MeowHash4, MeowHash4Op},
+#endif
+#if MEOW_INCLUDE_TRUNCATIONS
+    {(char *)"Meow64", (char *)"Meow 64-bit AES-NI 128-wide", MeowHashTruncate64},
+    {(char *)"Meow32", (char *)"Meow 32-bit AES-NI 128-wide", MeowHashTruncate32},
+#endif
+    
+#if MEOW_INCLUDE_OTHER_HASHES
+#if MEOW_T1HA_INCLUDED
+    {(char *)"t1ha64", (char *)"t1ha 64-bit", t1ha64},
+#endif
+    {(char *)"Falk128", (char *)"Falk Hash 128-bit", FalkHash128},
+    {(char *)"xx64", (char *)"xxHash 64-bit", xxHash64},
+    {(char *)"Met128", (char *)"Metro Hash 128-bit", MetroHash128},
+    {(char *)"City128", (char *)"City Hash 128-bit", CityHash128},
+#endif
+};
+
+static void
+PrintSize(FILE *Stream, double Size, int Fixed)
+{
+    char *Suffix = Fixed ? (char *)"b " : (char *)"b";
+    if(Size >= 1024.0)
+    {
+        Suffix = (char *)"kb";
+        Size /= 1024.0;
+        if(Size >= 1024.0)
+        {
+            Suffix = (char *)"mb";
+            Size /= 1024.0;
+            if(Size >= 1024.0)
+            {
+                Suffix = (char *)"gb";
+                Size /= 1024.0;
+            }
+        }
+    }
+    
+    fprintf(Stream, Fixed ? "%4.0f%s" : "%0.0f%s", Size, Suffix);
+}
+
+static void
+PrintHash(FILE *Stream, meow_hash Hash)
+{
+    fprintf(Stream, "%08X-%08X-%08X-%08X", Hash.u32[3], Hash.u32[2], Hash.u32[1], Hash.u32[0]);
+}


### PR DESCRIPTION
I've updated Meow to v0.2/Ragdoll.  Substantial changes include:

- Hash is now only officially defined at 128-bits and below.
- Much, much faster on 16byte-1kbyte hashes
- Improved benchmarking utility (meow_bench.cpp)
- Collision search utility (meow_search.cpp)
- Sanity checker (meow_test.cpp)
- Builds by default on Linux/CLANG now (build.sh included)

\- Casey