### PR TITLE
Fix example/test build on Apple Xcode/clang (no aligned_alloc)

### DIFF
--- a/meow_example.cpp
+++ b/meow_example.cpp
@@ -8,6 +8,7 @@
    ======================================================================== */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <memory.h>
 
 #if _MSC_VER
@@ -15,6 +16,16 @@
 // C, so you have to use their weird aligned malloc.
 #define aligned_alloc(a,b) _aligned_malloc(b,a)
 #define free _aligned_free
+#endif
+#if __APPLE__
+// NOTE: Apple Xcode/clang seems to not include aligned_alloc in the standard
+// library, so emulate via posix_memalign.
+static void* aligned_alloc(size_t alignment, size_t size)
+{
+    void* pointer = 0;
+    posix_memalign(&pointer, alignment, size);
+    return pointer;
+}
 #endif
 
 //

--- a/utils/meow_test.h
+++ b/utils/meow_test.h
@@ -20,6 +20,18 @@
 #define CATCH catch(...)
 #endif
 
+#if __APPLE__
+// NOTE: Apple Xcode/clang seems to not include aligned_alloc in the standard
+// library, so emulate via posix_memalign.
+static void* aligned_alloc(size_t alignment, size_t size)
+{
+    void* pointer = 0;
+    posix_memalign(&pointer, alignment, size);
+    return pointer;
+}
+#endif
+
+
 #include "meow_hash.h"
 
 #define ArrayCount(Array) (sizeof(Array)/sizeof((Array)[0]))


### PR DESCRIPTION
Xcode 9 clang ("Apple LLVM version 9.1.0") seems to be missing aligned_alloc in the C11 library. Use posix_memalign instead.

Fixes #19 - meow_test passes, benchmark works.