### PR TITLE
Aligned allocations on Windows also for clang/gcc

### DIFF
--- a/meow_example.cpp
+++ b/meow_example.cpp
@@ -11,13 +11,13 @@
 #include <stdlib.h>
 #include <memory.h>
 
-#if _MSC_VER
+#if _WIN32
 // NOTE(casey): Sadly, Visual Studio STILL doesn't seem to support standard
 // C, so you have to use their weird aligned malloc.
+// NOTE(mmozeiko): gcc/clang on Windows also should use these functions
 #define aligned_alloc(a,b) _aligned_malloc(b,a)
 #define free _aligned_free
-#endif
-#if __APPLE__
+#elif __APPLE__
 // NOTE: Apple Xcode/clang seems to not include aligned_alloc in the standard
 // library, so emulate via posix_memalign.
 static void* aligned_alloc(size_t alignment, size_t size)

--- a/utils/meow_test.h
+++ b/utils/meow_test.h
@@ -11,9 +11,6 @@
 #include <intrin.h>
 #define TRY __try
 #define CATCH __except(1)
-#define malloc(a) _aligned_malloc(a,16)
-#define aligned_alloc(a,b) _aligned_malloc(b,a)
-#define free _aligned_free
 #else
 #include <x86intrin.h>
 #define TRY try
@@ -29,6 +26,13 @@ static void* aligned_alloc(size_t alignment, size_t size)
     posix_memalign(&pointer, alignment, size);
     return pointer;
 }
+#elif _WIN32
+// NOTE(mmozeiko): MSVC/gcc/clang on Windows should use _aligned_...
+// functions from functions stdlib.h
+#include <stdlib.h>
+#define malloc(a) _aligned_malloc(a,16)
+#define aligned_alloc(a,b) _aligned_malloc(b,a)
+#define free _aligned_free
 #endif
 
 #include "meow_hash.h"


### PR DESCRIPTION
This will make all compilers (MSVC/gcc/clang) to use _aligned_malloc/_aligned_free functions on Windows. Linux build still works same as before.

See #22 for discussion.