### PR TITLE
Add support for ARMv8 architecture

### DIFF
--- a/meow_example.cpp
+++ b/meow_example.cpp
@@ -47,9 +47,17 @@ static void FreeEntireFile(entire_file *File);
 // NOTE(casey): Meow relies on definitions for __m128/256/512, so you must
 // have those defined either in your own include files or via a standard .h:
 #if _MSC_VER
+#if _M_AMD64 || _M_IX86
 #include <intrin.h>
+#elif _M_ARM64
+#include <arm64_neon.h>
+#endif
 #else
+#if __x86_64__ || __i386__
 #include <x86intrin.h>
+#elif __aarch64__
+#include <arm_neon.h>
+#endif
 #endif
 #include "meow_hash.h"
 

--- a/utils/meow_bench.cpp
+++ b/utils/meow_bench.cpp
@@ -11,6 +11,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __aarch64__
+// NOTE(mmozeiko): On ARM you normally cannot access cycle counter from user-space.
+// Download & build following kernel module that enables access to PMU cycle counter
+// from user-space code: https://github.com/zhiyisun/enable_arm_pmu
+#include <stdint.h>
+#include "enable_arm_pmu/armpmu_lib.h"
+#define __rdtsc() read_pmu()
+#endif
+
 #include "meow_test.h"
 
 //
@@ -87,6 +96,10 @@ FuddleBuffer(meow_u64 Size, void *Buffer)
 int
 main(int ArgCount, char **Args)
 {
+#if __aarch64__
+    enable_pmu(0x008);
+#endif
+
     //
     // NOTE(casey): Print the banner and status
     //
@@ -398,5 +411,9 @@ main(int ArgCount, char **Args)
     ExitProcess(0);
 #endif
     
+#if __aarch64__
+    disable_pmu(0x008);
+#endif
+
     return(0);
 }

--- a/utils/meow_search.cpp
+++ b/utils/meow_search.cpp
@@ -7,6 +7,7 @@
    
    ======================================================================== */
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <memory.h>

--- a/utils/meow_smhasher.cpp
+++ b/utils/meow_smhasher.cpp
@@ -8,9 +8,17 @@
    ======================================================================== */
 
 #if _MSC_VER
+#if _M_AMD64 || _M_IX86
 #include <intrin.h>
+#elif _M_ARM64
+#include <arm64_neon.h>
+#endif
 #else
+#if __x86_64__ || __i386__
 #include <x86intrin.h>
+#elif __aarch64__
+#include <arm_neon.h>
+#endif
 #endif
 
 #include "meow_hash.h"

--- a/utils/meow_test.h
+++ b/utils/meow_test.h
@@ -8,11 +8,19 @@
    ======================================================================== */
 
 #if _MSC_VER
+#if _M_AMD64 || _M_IX86
 #include <intrin.h>
+#elif _M_ARM64
+#include <arm64_neon.h>
+#endif
 #define TRY __try
 #define CATCH __except(1)
 #else
+#if __x86_64__ || __i386__
 #include <x86intrin.h>
+#elif __aarch64__
+#include <arm_neon.h>
+#endif
 #define TRY try
 #define CATCH catch(...)
 #endif


### PR DESCRIPTION
Tested on Pine A64. Verified that `meow_test`, `meow_search` and `meow_bench` works as expected.

Did extra check for correctness with custom code - generated 1024 hashes on laptop using Intel code-path, and then verified if hashes are the same on Pine A64 board.

Disassembly of hash function (without macroblocks): https://godbolt.org/z/TeEknx
