### PR TITLE
Add Travis CI integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+build.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+build_clang
+build_msvc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,156 @@
+language: shell
+install: true
+
+matrix:
+  include:
+
+  - name: "MSVC on Windows"
+    os: windows
+    # MSVC is already installed on Travis, keep it here just in case we need to use it later
+    #install:
+    #- choco install visualstudio2017-workload-vctools -y --package-parameters "--no-includeRecommended --add Microsoft.VisualStudio.Component.VC.x86.amd64 --add Microsoft.VisualStudio.Component.Windows10SDK"
+    script:
+    # test if meow_hash.h compiles as C
+    - touch test.c
+    - cmd.exe /C '"C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" amd64 && cl.exe /c /FImeow_intrinsics.h /FImeow_hash.h test.c'
+    # build & test
+    - cmd.exe /C '"C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" amd64 && build.bat'
+    - build_msvc/meow_test.exe
+    - build_msvc/meow_example.exe
+
+  - name: "clang on Windows"
+    os: windows
+    env:
+    - CC="/c/Program Files/LLVM/bin/clang"
+    - CXX="/c/Program Files/LLVM/bin/clang++"
+    install:
+    # MSVC is already installed on Travis, keep it here just in case we need to use it later
+    #- choco install visualstudio2017-workload-vctools -y --package-parameters "--no-includeRecommended --add Microsoft.VisualStudio.Component.VC.x86.amd64 --add Microsoft.VisualStudio.Component.Windows10SDK"
+    - choco upgrade llvm -y
+    - |-
+      "${CC}" --version
+    script:
+    # test if meow_hash.h compiles as C
+    - touch test.c
+    - |-
+      "${CC}" -c -maes -include meow_intrinsics.h -include meow_hash.h test.c
+    # build & test
+    - cmd.exe /C build.bat
+    - build_clang/meow_test.exe
+    - build_clang/meow_example.exe
+
+  - name: "gcc on Windows"
+    os: windows
+    env:
+    - CC="/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin/x86_64-w64-mingw32-gcc"
+    - CXX="/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin/x86_64-w64-mingw32-g++"
+    install:
+    - choco upgrade mingw -y
+    - ${CC} --version
+    script:
+    # test if meow_hash.h compiles as C
+    - touch test.c
+    - ${CC} -c -maes -include meow_intrinsics.h -include meow_hash.h test.c
+    # build & test
+    - ./build.sh
+    - build/meow_test.exe
+    - build/meow_example.exe
+
+  - name: "clang on Linux"
+    os: linux
+    dist: trusty
+    sudo: false
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - llvm-toolchain-trusty-7
+        packages:
+        - clang-7
+    env:
+    - CC=clang-7
+    - CXX=clang++-7
+    install:
+    - ${CC} --version
+    script:
+    # test if meow_hash.h compiles as C
+    - touch test.c
+    - ${CC} -c -maes -include meow_intrinsics.h -include meow_hash.h test.c
+    # build & test
+    - ./build.sh
+    - ./build/meow_test
+    - ./build/meow_example
+
+  - name: "gcc on Linux"
+    os: linux
+    dist: trusty
+    sudo: false
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-8
+    env:
+    - CC=gcc-8
+    - CXX=g++-8
+    install:
+    - ${CC} --version
+    script:
+    # test if meow_hash.h compiles as C
+    - touch test.c
+    - ${CC} -c -maes -include meow_intrinsics.h -include meow_hash.h test.c
+    # build & test
+    - ./build.sh
+    - ./build/meow_test
+    - ./build/meow_example
+
+  - name: "clang on Linux (ARMv8)"
+    os: linux
+    dist: trusty
+    sudo: false
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - llvm-toolchain-trusty-7
+        packages:
+        - clang-7
+        - lld-7
+        - libc6-dev-arm64-cross
+        - libgcc-4.8-dev-arm64-cross
+        - libstdc++-4.8-dev-arm64-cross
+    env:
+    - CC=clang-7
+    - CXX=clang++-7
+    install:
+    # use custom qemu verion because Ubuntu 14.04 has old qemu-user-static version
+    # which does not know how to emulate AES crypto opcodes on ARMv8
+    - wget -q http://rsync.alpinelinux.org/alpine/edge/main/x86_64/qemu-aarch64-2.12.1-r1.apk
+    - tar -xzf qemu-aarch64-2.12.1-r1.apk --warning=none --strip-components=2 usr/bin/qemu-aarch64
+    - ${CC} --version
+    script:
+    # test if meow_hash.h compiles as C
+    - touch test.c
+    - ${CC} --target=aarch64-linux-gnu --sysroot=/usr/aarch64-linux-gnu -mcpu=cortex-a53 -c -include meow_intrinsics.h -include meow_hash.h test.c
+    # build
+    - ${CXX} -O3 -fuse-ld=lld-7 --target=aarch64-linux-gnu --sysroot=/usr/aarch64-linux-gnu -mcpu=cortex-a53 meow_example.cpp -o meow_example
+    # test with qemu
+    - ./qemu-aarch64 -L /usr/aarch64-linux-gnu ./meow_example
+
+  - name: "clang on macOS"
+    os: osx
+    osx_image: xcode10.1
+    env:
+    - CC=clang
+    - CXX=clang++
+    install:
+    - ${CC} --version
+    script:
+    # test if meow_hash.h compiles as C
+    - touch test.c
+    - ${CC} -c -maes -include meow_intrinsics.h -include meow_hash.h test.c
+    # build & test
+    - ./build.sh
+    - ./build/meow_test
+    - ./build/meow_example

--- a/build.bat
+++ b/build.bat
@@ -17,7 +17,7 @@ popd
 :SkipMSVC
 
 
-where cl >nul 2>nul
+where clang++ >nul 2>nul
 IF %ERRORLEVEL% NEQ 0 (echo WARNING: clang++ is not in the path - please set up LLVM to do clang++ builds) && goto SkipCLANG
 
 echo -------------------

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+CXX=${CXX:-clang++}
+
 mkdir -p build
-clang++ $* -I./ meow_example.cpp -O3 -mavx -maes -obuild/meow_example
-clang++ $* -I./ utils/meow_test.cpp -O3 -mavx -maes -obuild/meow_test
-clang++ $* -I./ utils/meow_search.cpp -O3 -mavx -maes -obuild/meow_search
-clang++ $* -I./ utils/meow_bench.cpp -O3 -mavx -maes -obuild/meow_bench
+${CXX} $* -I. meow_example.cpp -O3 -mavx -maes -o build/meow_example
+${CXX} $* -I. utils/meow_test.cpp -O3 -mavx -maes -o build/meow_test
+${CXX} $* -I. utils/meow_search.cpp -O3 -mavx -maes -o build/meow_search
+${CXX} $* -I. utils/meow_bench.cpp -O3 -mavx -maes -o build/meow_bench

--- a/meow_hash.h
+++ b/meow_hash.h
@@ -553,7 +553,7 @@ MeowHash4(meow_u64 Seed, meow_u64 TotalLengthInBytes, void *SourceInit)
 // NOTE(casey): Streaming construction (optional)
 //
 
-struct meow_hash_state
+typedef struct meow_hash_state
 {
     union
     {
@@ -604,7 +604,7 @@ struct meow_hash_state
     
     meow_u8 Buffer[1 << MEOW_HASH_BLOCK_SIZE_SHIFT];
     int unsigned BufferLen;
-};
+} meow_hash_state;
 
 static void
 MeowHashBegin(meow_hash_state *State)

--- a/meow_intrinsics.h
+++ b/meow_intrinsics.h
@@ -204,6 +204,7 @@ Meow128_Set64x2_State(meow_u64 Low64, meow_u64 High64)
 #define MEOW_ANALYSIS_END
 #endif
 
+struct meow_hash_state;
 typedef meow_u128 meow_hash_implementation(meow_u64 Seed, meow_u64 Len, void *Source);
 typedef void meow_absorb_implementation(struct meow_hash_state *State, meow_u64 Len, void *Source);
 


### PR DESCRIPTION
Travis CI configuration adds 7 builds:

1) MSVC 2017 on Windows
2) clang on Windows
3) gcc on Windows
5) gcc on Linux
4) clang on Linux
6) clang on Linux (ARMv8)
7) clang on macOS

Each build compiles meow_hash.h as C code to see if it parses (only compiles, no linking).
Then runs the regular build.bat/sh and executes meow_test.exe and meow_example.exe.

Except ARMv8 build - it only builds meow_example and executes it with help of QEMU user emulator.

Example for build results: https://travis-ci.org/mmozeiko/meow_hash/builds/450296605
