### PR TITLE
Fix attribution URLs.

### DIFF
--- a/meow_hash_x64_aesni.h
+++ b/meow_hash_x64_aesni.h
@@ -86,11 +86,11 @@
       A number of valuable additions to Meow Hash were also contributed
       by other great folks along the way:
       
-      JEFF ROBERTS (https://radgametools.com) provided a super slick
+      JEFF ROBERTS (http://radgametools.com) provided a super slick
       way to handle the residual end-of-buffer bytes that dramatically
       improved Meow's small hash performance.
       
-      MARTINS MOZEIKO (https://matrins.ninja) ported Meow to ARM and
+      MARTINS MOZEIKO (https://martins.ninja) ported Meow to ARM and
       ANSI-C, and added the proper preprocessor dressing for clean
       compilation on a variety of compiler configurations.
       


### PR DESCRIPTION
The RAD Game Tools server does not seem to accept HTTPS traffic (it says "Connection Refused"), so I changed it to use plain HTTP instead. Maybe this is just a temporary thing? The second change fixes a typo.